### PR TITLE
fix: join tsconfig path with 'path.join'

### DIFF
--- a/packages/generator/src/utils/usesCustomTsConfigFilePath.ts
+++ b/packages/generator/src/utils/usesCustomTsConfigFilePath.ts
@@ -1,9 +1,11 @@
+import { join } from 'path'
+
 export const usesCustomTsConfigFilePath = async (
   path?: string,
 ): Promise<void> => {
   if (!path) return;
 
-  const customPath = `${process.cwd()}\\${path}`;
+  const customPath = join(process.cwd(), path);
 
   try {
     const tsconfig = await import(customPath);


### PR DESCRIPTION
Custom tsconfig didn't work on MacOS.