### PR TITLE
feat: make generator can be used as library

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -4,8 +4,8 @@
   "description": "Generates zod schemas from Prisma models with advanced validation",
   "author": "Chris Hörmann",
   "license": "MIT",
-  "main": ".",
-  "types": "dist",
+  "main": "dist/generator.js",
+  "types": "dist/generator.d.ts",
   "keywords": [
     "zod",
     "prisma",


### PR DESCRIPTION
Due to there is no index.js file in dist folder.
The main field can't be resolved.

Update main to `main:"dist/generator.js"`

Make generator can be used as a library.

![image](https://user-images.githubusercontent.com/17702287/214476992-2c79b892-7bae-4f52-add0-7a05b53d60bd.png)
