### PR TITLE
WIP Optional Default Relations

### DIFF
--- a/packages/generator/src/classes/extendedDMMFModel.ts
+++ b/packages/generator/src/classes/extendedDMMFModel.ts
@@ -27,6 +27,7 @@ export class ExtendedDMMFModel extends FormattedNames implements DMMF.Model {
   readonly scalarFields: ExtendedDMMFField[];
   readonly relationFields: ExtendedDMMFField[];
   readonly filterdRelationFields: ExtendedDMMFField[];
+  readonly filterdRelationFieldsWithDefaults: ExtendedDMMFField[];
   readonly enumFields: ExtendedDMMFField[];
   readonly hasRelationFields: boolean;
   readonly hasRequiredJsonFields: boolean;
@@ -59,6 +60,7 @@ export class ExtendedDMMFModel extends FormattedNames implements DMMF.Model {
     this.scalarFields = this._setScalarFields();
     this.relationFields = this._setRelationFields();
     this.filterdRelationFields = this._setFilteredRelationFields();
+    this.filterdRelationFieldsWithDefaults = this._setFilteredRelationFieldsWithDefaults();
     this.enumFields = this._setEnumfields();
     this.hasRelationFields = this._setHasRelationFields();
     this.hasRequiredJsonFields = this._setHasRequiredJsonFields();
@@ -112,6 +114,15 @@ export class ExtendedDMMFModel extends FormattedNames implements DMMF.Model {
       (field) => !field.type.includes(this.name),
     );
   }
+
+  private _setFilteredRelationFieldsWithDefaults() {
+    //TODO: Check if this relation has any Optional Defaults in it
+    // Again it is not accessible in this context
+    return this._setFilteredRelationFields().filter(
+      (field) => !field.type.includes(this.name),
+    );
+  }
+
 
   private _setHasRequiredJsonFields() {
     return this.fields.some((field) => field.isJsonType && field.isRequired);

--- a/packages/generator/src/functions/contentWriters/writeModelOrType.ts
+++ b/packages/generator/src/functions/contentWriters/writeModelOrType.ts
@@ -36,13 +36,22 @@ export const writeModelOrType = (
         new Set(
           model.filterdRelationFields
             .map((field) => {
-              return !dmmf.generatorConfig.isMongoDb
-                ? [
-                    `import { type ${field.type}WithRelations, ${field.type}WithRelationsSchema } from './${field.type}Schema'`,
+              if (!dmmf.generatorConfig.isMongoDb) {
+                 let importString = ` type ${field.type}WithRelations, ${field.type}WithRelationsSchema`
+                if (dmmf.generatorConfig.createOptionalDefaultValuesTypes ){
+                  // TODO: fix the above line 
+                  // We need information about the Location model, but the location model is not in this context
+                  // We only have access to what is in the filteredRelationFields 🤔
+                  importString += `, ${field.type}OptionalDefaultsWithRelationsSchema`
+                }
+                 return [
+                    `import {${importString} } from './${field.type}Schema'`,
                   ]
-                : [
+              } else {
+                 return [
                     `import { type ${field.type}, ${field.type}Schema } from './${field.type}Schema'`,
                   ];
+              }
             })
             .flat(),
         ),
@@ -265,7 +274,7 @@ export const writeModelOrType = (
       )
       .inlineBlock(() => {
         model.relationFields.forEach((field) => {
-          writeRelation({ writer, field });
+          writeRelation({ writer, field, writeOptionalDefaults:true });
         });
       })
       .write(`))`);

--- a/packages/generator/src/functions/fieldWriters/writeModelRelation.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelRelation.ts
@@ -14,11 +14,16 @@ export const writeRelation = ({
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.name}: `)
     .conditionalWrite(
-      !isMongoDb && !isPartial,
+      // NOTE: This condition below needs to be checked, or at least the logic can be above this function and we can leave this "dumb"
+      !isMongoDb && !isPartial && writeOptionalDefaults,
+      `z.lazy(() => ${field.type}OptionalDefaultsWithRelationsSchema)`,
+    )
+    .conditionalWrite(
+      !isMongoDb && !isPartial && !writeOptionalDefaults,
       `z.lazy(() => ${field.type}WithRelationsSchema)`,
     )
 
-    // if `isPartial` i `true`  we need to use `[ModelName]PartialWithRelationsSchema`
+    // if `isPartial` is `true`  we need to use `[ModelName]PartialWithRelationsSchema`
     // instead of`[ModelName]WithRelationsSchema` since this model is a model where all
     // fields are optional.
 


### PR DESCRIPTION
Hey Chris,

I was using Relations that had defaults in them which I wanted to be Optional

I assumed having both of the following would do this by default 🤔 
```
  createOptionalDefaultValuesTypes  = true
  createRelationValuesTypes = true
```

I gave updating the code a go but got stuck 😂 

```ts
import { type PostWithRelations, PostWithRelationsSchema, PostOptionalDefaultsWithRelationsSchema } from './PostSchema'
import { type ProfileWithRelations, ProfileWithRelationsSchema, ProfileOptionalDefaultsWithRelationsSchema } from './ProfileSchema'
import { type LocationWithRelations, LocationWithRelationsSchema, LocationOptionalDefaultsWithRelationsSchema } from './LocationSchema'
```

The issue with the code below is that if there is a relation model without any default fields in it, we should not point to the OptionalDefaultsRelation (`LocationOptionalDefaultsWithRelationsSchema` in this case)


If you have a workaround that would be great 🙏 

Otherwise if it is not possible, I am happy to close this PR 😄 


The current workaround is to enable partial types, so that the id in the relation is optional that way