### PR TITLE
Add missing With for nested relations

### DIFF
--- a/packages/generator/src/functions/contentWriters/writeModelOrType.ts
+++ b/packages/generator/src/functions/contentWriters/writeModelOrType.ts
@@ -270,7 +270,7 @@ export const writeModelOrType = (
             .write(': ')
             .conditionalWrite(
               !dmmf.generatorConfig.isMongoDb,
-              `${field.type}OptionalDefaultsRelations`,
+              `${field.type}OptionalDefaultsWithRelations`,
             )
             .conditionalWrite(dmmf.generatorConfig.isMongoDb, `${field.type}`)
             .conditionalWrite(field.isList, '[]')


### PR DESCRIPTION
Hey Chris,

I ran into a bug in the latest PR.

I have nested relations.

```ts
export type BankingProductDetailedOptionalDefaultsRelations = {
  Bank?: BankOptionalDefaultsRelations | null;
  additionalInformation?: AdditionalInfoDetailedOptionalDefaultsRelations | null; // This needs to be WithRelations
};

export type BankingProductDetailedOptionalDefaultsWithRelations = z.infer<typeof BankingProductDetailedOptionalDefaultsSchema> & BankingProductDetailedOptionalDefaultsRelations // This is missing the non relation data

export const BankingProductDetailedOptionalDefaultsWithRelationsSchema: z.ZodType<BankingProductDetailedOptionalDefaultsWithRelations> = BankingProductDetailedOptionalDefaultsSchema.merge(z.object({
  Bank: z.lazy(() => BankOptionalDefaultsWithRelationsSchema).nullish(),
  additionalInformation: z.lazy(() => AdditionalInfoDetailedOptionalDefaultsWithRelationsSchema).nullish(), // This is correct, but the Generics make TS not able to access the non relational data
}))
```

Without the `With` I could not access the non relational data, since Typescript does not know they exist

Let me know if there is anything I have not thought of by adding this, hope there is no downstream effects eg if there are not nested relations 🙏 

Thanks for this awesome package and the always quick responses (it is Easter, so no expectations 😄 )