### PR TITLE
Make array fields optional

### DIFF
--- a/packages/generator/src/functions/fieldWriters/writeModelFieldAdditions.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelFieldAdditions.ts
@@ -30,7 +30,7 @@ export const writeFieldAdditions = ({
       `.nullish()`,
     )
     .conditionalWrite(
-      writeOptionalDefaults && field.isOptionalOnDefaultValue,
+      (writeOptionalDefaults && field.isOptionalOnDefaultValue) || field.isList,
       `.optional()`,
     )
     .write(`,`)


### PR DESCRIPTION
Arrays can be zero or many. In the zero case, they should be optional as this is how prisma behaves on input, I don't need to specify array values.

Not sure if this is the best way to go about this though.

EG:
```prisma
model AdditionalInfoDetailed {
  id                           String                         @unique @default(cuid())
  BankingProductDetailed       BankingProductDetailed         @relation(fields: [productId], references: [id], onDelete: Cascade)
  productId                    String                         @unique /// @zod.custom.omit([model, input])
  overviewUri                  String?
  termsUri                     String?
  eligibilityUri               String?
  feesAndPricingUri            String?
  bundleUri                    String?
  AdditionalOverviewUris       AdditionalOverviewUris[]
  AdditionalTermsUris          AdditionalTermsUris[]
  AdditionalEligibilityUris    AdditionalEligibilityUris[]
  AdditionalFeesAndPricingUris AdditionalFeesAndPricingUris[]
  AdditionalBundleUris         AdditionalBundleUris[]

  @@index([productId])
}
```

Makes the following:

```ts
export const AdditionalInfoDetailedOptionalDefaultsWithRelationsSchema: z.ZodType<AdditionalInfoDetailedOptionalDefaultsWithRelations> = AdditionalInfoDetailedOptionalDefaultsSchema.merge(z.object({
  BankingProductDetailed: z.lazy(() => BankingProductDetailedOptionalDefaultsWithRelationsSchema),
  AdditionalOverviewUris: z.lazy(() => AdditionalOverviewUrisOptionalDefaultsWithRelationsSchema).array(),
  AdditionalTermsUris: z.lazy(() => AdditionalTermsUrisOptionalDefaultsWithRelationsSchema).array(),
  AdditionalEligibilityUris: z.lazy(() => AdditionalEligibilityUrisOptionalDefaultsWithRelationsSchema).array(),
  AdditionalFeesAndPricingUris: z.lazy(() => AdditionalFeesAndPricingUrisOptionalDefaultsWithRelationsSchema).array(),
  AdditionalBundleUris: z.lazy(() => AdditionalBundleUrisOptionalDefaultsWithRelationsSchema).array(),
}))
```

Since the arrays can be empty, I want them to be `.optional()`.

I am using these Schemas to parse API responses that I am then putting into `prisma.create`, which does force me to input the array values.

This may not be right, so happy to discuss or if there is a better way would love some pointers 🙏  😄 

I am using partials in the meantime, which may be the better way to go