### PR TITLE
Adjust Json field handling

### DIFF
--- a/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMF.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMF.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 describe('testSimpleModelNoValidators', async () => {

--- a/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMFField.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMFField.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { GeneratorConfig } from '../../../../schemas';
 import { getStringVariants } from '../../../../utils/getStringVariants';
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 export const DEFAULT_GENERATOR_CONFIG: GeneratorConfig = {

--- a/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMFModel.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testCustomClassProperties/extendedDMMFModel.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 
-import { getStringVariants } from '../../../../utils/getStringVariants';
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
-import { loadDMMF } from '../../utils/loadDMMF';
 import { DEFAULT_GENERATOR_CONFIG } from './extendedDMMFField.test';
+import { getStringVariants } from '../../../../utils/getStringVariants';
+import { ExtendedDMMF } from '../../../extendedDMMF';
+import { loadDMMF } from '../../utils/loadDMMF';
 
 describe('testSimpleModelNoValidators', async () => {
   const dmmf = await loadDMMF(`${__dirname}/extendedDMMFModel.prisma`);

--- a/packages/generator/src/classes/__tests__/cases/testValidators/custom.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/custom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 describe('test date validators', async () => {
   const dmmf = await loadDMMF(`${__dirname}/custom.prisma`);

--- a/packages/generator/src/classes/__tests__/cases/testValidators/date.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/date.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 describe('test date validators', async () => {
   const dmmf = await loadDMMF(`${__dirname}/date.prisma`);

--- a/packages/generator/src/classes/__tests__/cases/testValidators/number.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/number.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 describe('test number validators', async () => {
   const dmmf = await loadDMMF(`${__dirname}/number.prisma`);

--- a/packages/generator/src/classes/__tests__/cases/testValidators/string.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 describe('test string validators', async () => {
   const dmmf = await loadDMMF(`${__dirname}/string.prisma`);

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidCustomError.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidCustomError.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it('should throw a custom error key is not valid', async () => {

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidPrismaType.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidPrismaType.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it('should throw if the wrong key is used', async () => {

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidType.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidType.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it('should throw if an invalid key is used', async () => {

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidator.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidator.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it("should throw if the wrong validator is used for a type that doesn't support it", async () => {

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidatorKey.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidatorKey.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it("should throw if the wrong validator key is used for a type that doesn't support it", async () => {

--- a/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidatorText.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/validatorErrors/invalidValidatorText.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { ExtendedDMMF } from '../../../ExtendedDMMF';
+import { ExtendedDMMF } from '../../../extendedDMMF';
 import { loadDMMF } from '../../utils/loadDMMF';
 
 it('should throw if a validator text is used', async () => {

--- a/packages/generator/src/classes/extendedDMMFModel.ts
+++ b/packages/generator/src/classes/extendedDMMFModel.ts
@@ -266,7 +266,7 @@ export class ExtendedDMMFModel extends FormattedNames implements DMMF.Model {
 
     if (this.hasRequiredJsonFields) {
       statements.push(
-        `import { InputJsonValue } from "../${inputTypePath}/InputJsonValue"`,
+        `import { JsonValue } from "../${inputTypePath}/JsonValue"`,
       );
     }
 

--- a/packages/generator/src/functions/contentWriters/writeTransformJsonNull.ts
+++ b/packages/generator/src/functions/contentWriters/writeTransformJsonNull.ts
@@ -28,7 +28,7 @@ export const writeTransformJsonNull = ({
     .write(`export const transformJsonNull = (v?: NullableJsonInput) => `)
     .inlineBlock(() => {
       writer
-        .writeLine(`if (!v || v === 'DbNull') return Prisma.DbNull;`)
+        .writeLine(`if (v === 'DbNull') return Prisma.DbNull;`)
         .writeLine(`if (v === 'JsonNull') return Prisma.JsonNull;`)
         .writeLine(`return v;`);
     })

--- a/packages/generator/src/functions/fieldWriters/writeModelJson.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelJson.ts
@@ -4,7 +4,7 @@ export const writeJson = ({ writer, field }: WriteFieldOptions) => {
   writer
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.formattedNames.original}: `)
-    .conditionalWrite(field.isRequired, `InputJsonValue`)
+    .conditionalWrite(field.isRequired, `JsonValue`)
     .conditionalWrite(!field.isRequired, `NullableJsonValue`)
     .conditionalWrite(field.isList, `.array()`)
     .conditionalWrite(!field.isRequired, `.optional()`)

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -30,6 +30,6 @@
     "validator": "^13.9.0",
     "vitest": "^0.25.8",
     "zod": "^3.21.1",
-    "zod-prisma-types": "workspace:2.5.4"
+    "zod-prisma-types": "workspace:2.5.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         specifier: ^3.21.1
         version: 3.21.1
       zod-prisma-types:
-        specifier: workspace:2.5.4
+        specifier: workspace:2.5.6
         version: link:../generator
     devDependencies:
       '@types/node':


### PR DESCRIPTION
This is an attempt to address https://github.com/chrishoermann/zod-prisma-types/issues/134
The relevant tests still pass but I'm not sure if I'm taking all use cases into consideration.

- Uses `JsonValue` instead of `InputJsonValue` for required Json model fields
- Adjusts `transformJsonNull`

Misc fixes:
- updates generator version in usage workspace package.json
- updates `extendedDMMF` import path in tests