### PR TITLE
Add export line inside code block

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -451,9 +451,9 @@ export const UserPartialWithRelationsSchema: z.ZodType<UserPartialWithRelations>
       location: z.lazy(() => LocationPartialWithRelationsSchema).nullable(),
     }),
   ).partial();
-```
 
 export type UserPartial = z.infer<typeof UserPartialSchema>;
+```
 
 ### `useDefaultValidators`
 


### PR DESCRIPTION
In the final code block of the createPartialTypes option section, the final export line was left outside the code block. Just a minor typo.

![image](https://github.com/chrishoermann/zod-prisma-types/assets/59508264/12b93f6a-ba5b-477f-8848-30a74a82a2f2)
