### PR TITLE
Fix template string not valid in `VALIDATOR_TYPE_REGEX`

### DIFF
--- a/packages/generator/src/classes/extendedDMMFField/02_extendedDMMFFieldValidatorMatch.ts
+++ b/packages/generator/src/classes/extendedDMMFField/02_extendedDMMFFieldValidatorMatch.ts
@@ -17,7 +17,7 @@ import { GeneratorConfig } from '../../schemas';
 // "u" flag for Unicode support
 
 export const VALIDATOR_TYPE_REGEX =
-  /@zod(?<import>\.import\(\[(?<imports>[\w\s"@'${}/,;:.~*-]+)\]\))?\.(?<type>[\w]+){1}(?<customErrors>\([{][\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M} (),'ʼ"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]+[}]\))?(?<validatorPattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{Punctuation}\p{M}\p{N} (),.'"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]*[)])?/u;
+  /@zod(?<import>\.import\(\[(?<imports>[\w\s"@'${}/,;:.~*-]+)\]\))?\.(?<type>[\w]+){1}(?<customErrors>\([{][\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M} (),'"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]+[}]\))?(?<validatorPattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{Punctuation}\p{M}\p{N} (),.'`"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]*[)])?/u;
 
 /////////////////////////////////////////////////
 // CLASS

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
@@ -107,6 +107,21 @@ export function testExtendedDMMFFieldValidatorMatch<
       );
     });
 
+    it(`should load a class with docs and custom validator containing template string`, async () => {
+      const field = getField({
+        documentation:
+          'some text in docs  @zod.custom.use(z.literal(`foo${string}`))',
+      });
+      const match = field?.['_validatorMatch'];
+      expect(match?.groups?.['validatorPattern']).toBe(
+        '.use(z.literal(`foo${string}`))',
+      );
+      expect(field?.clearedDocumentation).toBe('some text in docs');
+      expect(field.documentation).toBe(
+        'some text in docs  @zod.custom.use(z.literal(`foo${string}`))',
+      );
+    });
+
     it(`should match japanese characters in the regex`, async () => {
       const match = VALIDATOR_TYPE_REGEX.exec(
         `@zod.string({ invalid_type_error: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" }).min(5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })`,


### PR DESCRIPTION
Add the ` character in the ```VALIDATOR_TYPE_REGEX``` in order to support template strings with custom validator.

Fixes #231 