### PR TITLE
fix(generator): Nullability of JSON field is reversed

### DIFF
--- a/packages/generator/src/functions/fieldWriters/writeModelJson.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelJson.ts
@@ -5,7 +5,7 @@ export const writeJson = ({ writer, field }: WriteFieldOptions) => {
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.formattedNames.original}: JsonValueSchema`)
     .conditionalWrite(field.isList, `.array()`)
-    .conditionalWrite(!field.isNullable, `.nullable()`) // needs to be nullable instead of optional to adhere to the type returned by Prisma
+    .conditionalWrite(field.isNullable, `.nullable()`) // needs to be nullable instead of optional to adhere to the type returned by Prisma
     .write(`,`)
     .newLine();
 };


### PR DESCRIPTION
Fixes #238 

Tested locally with a simple schema:
```prisma
model User {
  id String @unique
  name String
  bio Json
}

model UserOptional {
  id String @unique
  name String?
  bio Json?
}
```
now correctly generates
```ts
export const UserSchema = z.object({
  id: z.string(),
  name: z.string(),
  bio: JsonValueSchema,
})

export const UserOptionalSchema = z.object({
  id: z.string(),
  name: z.string().nullable(),
  bio: JsonValueSchema.nullable(),
})
```