### PR TITLE
add relation value support when using mongodb provider

### DIFF
--- a/packages/generator/src/classes/extendedDMMFField/01_extendedDMMFFieldBase.ts
+++ b/packages/generator/src/classes/extendedDMMFField/01_extendedDMMFFieldBase.ts
@@ -39,6 +39,7 @@ export class ExtendedDMMFFieldBase
   readonly isJsonType: boolean;
   readonly isBytesType: boolean;
   readonly isDecimalType: boolean;
+  readonly isCompositeType: boolean;
   readonly isOptionalOnDefaultValue: boolean;
   readonly isOptionalDefaultField: boolean;
 
@@ -74,6 +75,7 @@ export class ExtendedDMMFFieldBase
     this.isJsonType = this._setIsJsonType();
     this.isBytesType = this._setIsBytesType();
     this.isDecimalType = this._setIsDecimalType();
+    this.isCompositeType = this._setIsCompositeType();
     this.isOptionalOnDefaultValue = this._setDefaultValueOptional();
     this.isOptionalDefaultField = this._setIsOptionalDefaultField();
 
@@ -90,6 +92,10 @@ export class ExtendedDMMFFieldBase
 
   private _setIsDecimalType() {
     return this.type === 'Decimal';
+  }
+
+  private _setIsCompositeType() {
+    return !this.relationName && this.kind === 'object';
   }
 
   private _setIsNullable() {

--- a/packages/generator/src/classes/extendedDMMFField/index.ts
+++ b/packages/generator/src/classes/extendedDMMFField/index.ts
@@ -39,6 +39,12 @@ export interface ExtendedDMMFField extends DMMF.Field, FormattedNames {
    * Is used in writer functions.
    * Makes the code more readable when it is in a seperate property.
    */
+  readonly isCompositeType: boolean;
+
+  /**
+   * Is used in writer functions.
+   * Makes the code more readable when it is in a seperate property.
+   */
   readonly isOptionalOnDefaultValue: boolean;
 
   /**

--- a/packages/generator/src/functions/fieldWriters/writeModelRelation.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelRelation.ts
@@ -12,29 +12,16 @@ export const writeRelation = ({
   isPartial?: boolean;
   isOptionalDefaults?: boolean;
 }) => {
-  const isMongoDb = field.generatorConfig.provider === 'mongodb';
-
   writer
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.name}: `)
-    .conditionalWrite(
-      !isMongoDb && !isPartial && !isOptionalDefaults,
-      `z.lazy(() => ${field.type}WithRelationsSchema)`,
-    )
-
+    .write(`z.lazy(() => ${field.type}`)
     // if `isPartial` is `true`  we need to use `[ModelName]PartialWithRelationsSchema`
     // instead of`[ModelName]WithRelationsSchema` since this model is a model where all
     // fields are optional.
-
-    .conditionalWrite(
-      !isMongoDb && isPartial,
-      `z.lazy(() => ${field.type}PartialWithRelationsSchema)`,
-    )
-    .conditionalWrite(
-      !isMongoDb && isOptionalDefaults,
-      `z.lazy(() => ${field.type}OptionalDefaultsWithRelationsSchema)`,
-    )
-    .conditionalWrite(isMongoDb, `z.lazy(() => ${field.type}Schema)`);
-
+    .conditionalWrite(isPartial, 'Partial')
+    .conditionalWrite(isOptionalDefaults, 'OptionalDefaults')
+    .conditionalWrite(!field.isCompositeType, 'WithRelations')
+    .write('Schema)');
   writeFieldAdditions({ writer, field, writeOptionalDefaults });
 };

--- a/packages/generator/src/functions/writeSingleFileTypeStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileTypeStatements.ts
@@ -11,13 +11,13 @@ export const writeSingleFileTypeStatements: WriteStatements = (
 ) => {
   if (
     !dmmf.generatorConfig.createModelTypes ||
-    dmmf.generatorConfig.provider !== 'mongodb'
+    dmmf.datamodel.types.length === 0
   )
     return;
 
   fileWriter.writer.blankLine();
 
-  fileWriter.writeHeading(`MONGODB TYPES`, 'FAT');
+  fileWriter.writeHeading(`COMPOSITE TYPES`, 'FAT');
 
   dmmf.datamodel.types.forEach((type) => {
     fileWriter.writeHeading(`${type.formattedNames.upperCaseSpace}`, 'SLIM');


### PR DESCRIPTION
Fixes: #254

This commit adds a _isCompositeType_ boolean to the _ExtendedDMMFField_ class. It removes checks for the MongoDB provider, and instead checks if a field is a composite type on a field by field basis, which means the schemas can now contain nested "WithRelations" model schemas, like any other provider can.