### PR TITLE
feat: Support Japanese long vowel mark ー (chōonpu)

### DIFF
--- a/packages/generator/src/classes/extendedDMMFField/02_extendedDMMFFieldValidatorMatch.ts
+++ b/packages/generator/src/classes/extendedDMMFField/02_extendedDMMFFieldValidatorMatch.ts
@@ -17,7 +17,7 @@ import { GeneratorConfig } from '../../schemas';
 // "u" flag for Unicode support
 
 export const VALIDATOR_TYPE_REGEX =
-  /@zod(?<import>\.import\(\[(?<imports>[\w\s"@'${}/,;:.~*-]+)\]\))?\.(?<type>[\w]+){1}(?<customErrors>\([{][\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M} (),'"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]+[}]\))?(?<validatorPattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{Punctuation}\p{M}\p{N} (),.'`"。、|\\:+*#!§$%&/{}[\]=?~><°^\\-]*[)])?/u;
+  /@zod(?<import>\.import\(\[(?<imports>[\w\s"@'${}/,;:.~*-]+)\]\))?\.(?<type>[\w]+){1}(?<customErrors>\([{][\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M} (),'"。、ー|\\:+*#!§$%&/{}[\]=?~><°^\\-]+[}]\))?(?<validatorPattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{Punctuation}\p{M}\p{N} (),.'`"。、ー|\\:+*#!§$%&/{}[\]=?~><°^\\-]*[)])?/u;
 
 /////////////////////////////////////////////////
 // CLASS

--- a/packages/generator/src/classes/extendedDMMFField/07_extendedDMMFFieldValidatorMap.ts
+++ b/packages/generator/src/classes/extendedDMMFField/07_extendedDMMFFieldValidatorMap.ts
@@ -118,7 +118,7 @@ export const BIGINT_VALIDATOR_MESSAGE_REGEX =
 // CUSTOM
 // ----------------------------------------
 export const CUSTOM_VALIDATOR_MESSAGE_REGEX =
-  /(?<validator>use|array|omit)(\()(?<pattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M}ʼ (),.'"。、:+\-*#!§$%&/{}[\]=?~><°^|]+)\)/u;
+  /(?<validator>use|array|omit)(\()(?<pattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M}ʼ (),.'"。、ー:+\-*#!§$%&/{}[\]=?~><°^|]+)\)/u;
 
 export const CUSTOM_OMIT_VALIDATOR_MESSAGE_REGEX =
   /(?<validator>omit)(\()(?<pattern>[\w ,'"[\]]+)\)/;
@@ -126,7 +126,7 @@ export const CUSTOM_OMIT_VALIDATOR_MESSAGE_REGEX =
 // ARRAY
 // ----------------------------------------
 export const ARRAY_VALIDATOR_MESSAGE_REGEX =
-  /(?<validator>array)(\((?<pattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M}ʼ (),.'"。、:+\-*#!§$%&/{}[\]=?~><°^]+)\))/u;
+  /(?<validator>array)(\((?<pattern>[\w\p{Script=Latin}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}\p{M}ʼ (),.'"。、ー:+\-*#!§$%&/{}[\]=?~><°^]+)\))/u;
 
 /////////////////////////////////////////////
 // REGEX MAPS

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
@@ -124,27 +124,14 @@ export function testExtendedDMMFFieldValidatorMatch<
 
     it(`should match japanese characters in the regex`, async () => {
       const match = VALIDATOR_TYPE_REGEX.exec(
-        `@zod.string({ invalid_type_error: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" }).min(5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })`,
+        `@zod.string({ invalid_type_error: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" }).min(5, { message: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })`,
       );
 
       expect(match?.groups?.['customErrors']).toBe(
-        '({ invalid_type_error: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })',
+        '({ invalid_type_error: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })',
       );
       expect(match?.groups?.['validatorPattern']).toBe(
-        '.min(5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })',
-      );
-    });
-
-    it(`should match japanese character chōonpu (prolonged sound mark) in the regex`, async () => {
-      const match = VALIDATOR_TYPE_REGEX.exec(
-        `@zod.string({ invalid_type_error: "長音符ーが含まれる必要があります。" }).min(5, { message: "長音符ーが含まれる必要があります。" })`,
-      );
-
-      expect(match?.groups?.['customErrors']).toBe(
-        '({ invalid_type_error: "長音符ーが含まれる必要があります。" })',
-      );
-      expect(match?.groups?.['validatorPattern']).toBe(
-        '.min(5, { message: "長音符ーが含まれる必要があります。" })',
+        '.min(5, { message: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })',
       );
     });
 

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/02_extendedDMMFFieldValidatorMatch.test.ts
@@ -135,6 +135,19 @@ export function testExtendedDMMFFieldValidatorMatch<
       );
     });
 
+    it(`should match japanese character chōonpu (prolonged sound mark) in the regex`, async () => {
+      const match = VALIDATOR_TYPE_REGEX.exec(
+        `@zod.string({ invalid_type_error: "長音符ーが含まれる必要があります。" }).min(5, { message: "長音符ーが含まれる必要があります。" })`,
+      );
+
+      expect(match?.groups?.['customErrors']).toBe(
+        '({ invalid_type_error: "長音符ーが含まれる必要があります。" })',
+      );
+      expect(match?.groups?.['validatorPattern']).toBe(
+        '.min(5, { message: "長音符ーが含まれる必要があります。" })',
+      );
+    });
+
     it(`should match nested custom annotations`, async () => {
       const match = VALIDATOR_TYPE_REGEX.exec(
         `@zod.custom.use(z.object({contents: z.array(z.object({locale: z.string(), content: z.string()}))}))`,

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/07_extendedDMMFFieldValidatorMap.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/07_extendedDMMFFieldValidatorMap.test.ts
@@ -42,99 +42,99 @@ export function testExtendedDMMFFieldValidatorMap<
   describe("ExtendedDMMFFieldValidatorMap's regex with japanese chars", () => {
     it(`string validator number should return match for regex with japanese chars`, async () => {
       const result = STRING_VALIDATOR_NUMBER_AND_MESSAGE_REGEX.exec(
-        ".min(5, {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".min(5, {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('min');
       expect(result?.groups?.number).toBe('5');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`string validator message should return match for regex with japanese chars`, async () => {
       const result = STRING_VALIDATOR_MESSAGE_REGEX.exec(
-        ".email({message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".email({message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('email');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`string validator string should return match for regex with japanese chars`, async () => {
       const result = STRING_VALIDATOR_STRING_AND_MESSAGE_REGEX.exec(
-        ".startsWith('ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".startsWith('ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('startsWith');
       expect(result?.groups?.string).toBe(
-        "'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'",
+        "'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'",
       );
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`number validator number should return match for regex with japanese chars`, async () => {
       const result = NUMBER_VALIDATOR_NUMBER_AND_MESSAGE_REGEX.exec(
-        ".min(2, {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".min(2, {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('min');
       expect(result?.groups?.number).toBe('2');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`number validator message should return match for regex with japanese chars`, async () => {
       const result = NUMBER_VALIDATOR_MESSAGE_REGEX.exec(
-        ".int({message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".int({message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('int');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`date validator number should return match for regex with japanese chars`, async () => {
       const result = DATE_VALIDATOR_NUMBER_AND_MESSAGE_REGEX.exec(
-        ".min(new Date(01-01-2022), { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' })",
+        ".min(new Date(01-01-2022), { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' })",
       );
       expect(result?.groups?.validator).toBe('min');
       expect(result?.groups?.date).toBe('new Date(01-01-2022)');
       expect(result?.groups?.message).toBe(
-        "{ message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' }",
+        "{ message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' }",
       );
     });
 
     it(`bigint validator number should return match for regex with japanese chars`, async () => {
       const result = BIGINT_VALIDATOR_NUMBER_AND_MESSAGE_REGEX.exec(
-        ".gt(2n, { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' })",
+        ".gt(2n, { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' })",
       );
       expect(result?.groups?.validator).toBe('gt');
       expect(result?.groups?.number).toBe('2n');
       expect(result?.groups?.message).toBe(
-        "{ message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' }",
+        "{ message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' }",
       );
     });
 
     it(`bigint validator message should return match for regex with japanese chars`, async () => {
       const result = BIGINT_VALIDATOR_MESSAGE_REGEX.exec(
-        ".positive({message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".positive({message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('positive');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`custom validator message should return match for regex with japanese chars`, async () => {
       const result = CUSTOM_VALIDATOR_MESSAGE_REGEX.exec(
-        ".use(z.string.min(2, { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' }))",
+        ".use(z.string.min(2, { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' }))",
       );
 
       expect(result?.groups?.validator).toBe('use');
       expect(result?.groups?.pattern).toBe(
-        "z.string.min(2, { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' })",
+        "z.string.min(2, { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' })",
       );
     });
 
@@ -151,12 +151,12 @@ export function testExtendedDMMFFieldValidatorMap<
 
     it(`array validator message should return match for regex with japanese chars`, async () => {
       const result = CUSTOM_VALIDATOR_MESSAGE_REGEX.exec(
-        "array(min(2, { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' }))",
+        "array(min(2, { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' }))",
       );
 
       expect(result?.groups?.validator).toBe('array');
       expect(result?.groups?.pattern).toBe(
-        "min(2, { message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' })",
+        "min(2, { message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' })",
       );
     });
   });

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/10_extendedDMMFFieldArrayValidatorString.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/10_extendedDMMFFieldArrayValidatorString.test.ts
@@ -33,42 +33,42 @@ export function testExtendedDMMFFieldArrayValidatorString<
   describe("ExtendedDMMFFieldValidatorMap's regex", () => {
     it(`array validator number should return match for regex with japanese chars`, async () => {
       const result = ARRAY_VALIDATOR_NUMBER_AND_MESSAGE_REGEX.exec(
-        ".min(5, {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".min(5, {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('min');
       expect(result?.groups?.number).toBe('5');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`array validator number or string should return match for regex with japanese chars`, async () => {
       const resultOne = ARRAY_VALIDATOR_NUMBER_OR_STRING_AND_MESSAGE_REGEX.exec(
-        ".min(5, {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".min(5, {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(resultOne?.groups?.validator).toBe('min');
       expect(resultOne?.groups?.number).toBe('5');
       expect(resultOne?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
 
       const resultTwo = ARRAY_VALIDATOR_NUMBER_OR_STRING_AND_MESSAGE_REGEX.exec(
-        ".min(string, {message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".min(string, {message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(resultTwo?.groups?.validator).toBe('min');
       expect(resultTwo?.groups?.number).toBe('string');
       expect(resultTwo?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
 
     it(`array validator message should return match for regex with japanese chars`, async () => {
       const result = ARRAY_VALIDATOR_WITH_MESSAGE_REGEX.exec(
-        ".nonempty({message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'})",
+        ".nonempty({message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'})",
       );
       expect(result?.groups?.validator).toBe('nonempty');
       expect(result?.groups?.message).toBe(
-        "{message: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。'}",
+        "{message: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。'}",
       );
     });
   });

--- a/packages/generator/src/utils/__tests__/validateCustomError.test.ts
+++ b/packages/generator/src/utils/__tests__/validateCustomError.test.ts
@@ -11,19 +11,19 @@ import {
 describe(`ExtendedDMMFFieldValidatorCustomErrors`, () => {
   it(`array validator number should return match for regex with japanese chars`, async () => {
     const result = VALIDATOR_CUSTOM_ERROR_REGEX.exec(
-      "({ invalid_type_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' })",
+      "({ invalid_type_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' })",
     );
     expect(result?.groups?.object).toBe(
-      "{ invalid_type_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' }",
+      "{ invalid_type_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' }",
     );
     expect(result?.groups?.messages).toBe(
-      " invalid_type_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' ",
+      " invalid_type_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' ",
     );
   });
 
   it(`array validator number should return match for regex with japanese chars`, async () => {
     const messageArray =
-      " invalid_type_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' "
+      " invalid_type_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', required_error: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。', description: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' "
         .replace(VALIDATOR_CUSTOM_ERROR_MESSAGE_REGEX, '')
         .match(VALIDATOR_CUSTOM_ERROR_SPLIT_KEYS_REGEX);
 
@@ -49,7 +49,7 @@ describe(`ExtendedDMMFFieldValidatorCustomErrors`, () => {
   });
   it(`array validator number should return match for regex with japanese chars`, async () => {
     const messageArray =
-      " invalid_type_error: 'ÁÀȦÂÄǞǍĂĀÃÅǺǼǢĆĊĈČĎḌḐḒÉÈĖÊËĚĔĒẼE̊ẸǴĠĜǦĞG̃ĢĤḤáàȧâäǟǎăāãåǻǽǣćċĉčďḍḑḓéèėêëěĕēẽe̊ẹǵġĝǧğg̃ģĥḥÍÌİÎÏǏĬĪĨỊĴĶǨĹĻĽĿḼM̂M̄ʼNŃN̂ṄN̈ŇN̄ÑŅṊÓÒȮȰÔÖȪǑŎŌÕȬŐỌǾƠíìiîïǐĭīĩịĵķǩĺļľŀḽm̂m̄ŉńn̂ṅn̈ňn̄ñņṋóòôȯȱöȫǒŏōõȭőọǿơP̄ŔŘŖŚŜṠŠȘṢŤȚṬṰÚÙÛÜǓŬŪŨŰŮỤẂẀŴẄÝỲŶŸȲỸŹŻŽẒǮp̄ŕřŗśŝṡšşṣťțṭṱúùûüǔŭūũűůụẃẁŵẅýỳŷÿȳỹźżžẓǯßœŒçÇ', required_error: 'ÁÀȦÂÄǞǍĂĀÃÅǺǼǢĆĊĈČĎḌḐḒÉÈĖÊËĚĔĒẼE̊ẸǴĠĜǦĞG̃ĢĤḤáàȧâäǟǎăāãåǻǽǣćċĉčďḍḑḓéèėêëěĕēẽe̊ẹǵġĝǧğg̃ģĥḥÍÌİÎÏǏĬĪĨỊĴĶǨĹĻĽĿḼM̂M̄ʼNŃN̂ṄN̈ŇN̄ÑŅṊÓÒȮȰÔÖȪǑŎŌÕȬŐỌǾƠíìiîïǐĭīĩịĵķǩĺļľŀḽm̂m̄ŉńn̂ṅn̈ňn̄ñņṋóòôȯȱöȫǒŏōõȭőọǿơP̄ŔŘŖŚŜṠŠȘṢŤȚṬṰÚÙÛÜǓŬŪŨŰŮỤẂẀŴẄÝỲŶŸȲỸŹŻŽẒǮp̄ŕřŗśŝṡšşṣťțṭṱúùûüǔŭūũűůụẃẁŵẅýỳŷÿȳỹźżžẓǯßœŒçÇ', description: 'ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。' "
+      " invalid_type_error: 'ÁÀȦÂÄǞǍĂĀÃÅǺǼǢĆĊĈČĎḌḐḒÉÈĖÊËĚĔĒẼE̊ẸǴĠĜǦĞG̃ĢĤḤáàȧâäǟǎăāãåǻǽǣćċĉčďḍḑḓéèėêëěĕēẽe̊ẹǵġĝǧğg̃ģĥḥÍÌİÎÏǏĬĪĨỊĴĶǨĹĻĽĿḼM̂M̄ʼNŃN̂ṄN̈ŇN̄ÑŅṊÓÒȮȰÔÖȪǑŎŌÕȬŐỌǾƠíìiîïǐĭīĩịĵķǩĺļľŀḽm̂m̄ŉńn̂ṅn̈ňn̄ñņṋóòôȯȱöȫǒŏōõȭőọǿơP̄ŔŘŖŚŜṠŠȘṢŤȚṬṰÚÙÛÜǓŬŪŨŰŮỤẂẀŴẄÝỲŶŸȲỸŹŻŽẒǮp̄ŕřŗśŝṡšşṣťțṭṱúùûüǔŭūũűůụẃẁŵẅýỳŷÿȳỹźżžẓǯßœŒçÇ', required_error: 'ÁÀȦÂÄǞǍĂĀÃÅǺǼǢĆĊĈČĎḌḐḒÉÈĖÊËĚĔĒẼE̊ẸǴĠĜǦĞG̃ĢĤḤáàȧâäǟǎăāãåǻǽǣćċĉčďḍḑḓéèėêëěĕēẽe̊ẹǵġĝǧğg̃ģĥḥÍÌİÎÏǏĬĪĨỊĴĶǨĹĻĽĿḼM̂M̄ʼNŃN̂ṄN̈ŇN̄ÑŅṊÓÒȮȰÔÖȪǑŎŌÕȬŐỌǾƠíìiîïǐĭīĩịĵķǩĺļľŀḽm̂m̄ŉńn̂ṅn̈ňn̄ñņṋóòôȯȱöȫǒŏōõȭőọǿơP̄ŔŘŖŚŜṠŠȘṢŤȚṬṰÚÙÛÜǓŬŪŨŰŮỤẂẀŴẄÝỲŶŸȲỸŹŻŽẒǮp̄ŕřŗśŝṡšşṣťțṭṱúùûüǔŭūũűůụẃẁŵẅýỳŷÿȳỹźżžẓǯßœŒçÇ', description: 'ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。' "
         .replace(VALIDATOR_CUSTOM_ERROR_MESSAGE_REGEX, '')
         .match(VALIDATOR_CUSTOM_ERROR_SPLIT_KEYS_REGEX);
 

--- a/packages/usage/prisma/schema.prisma
+++ b/packages/usage/prisma/schema.prisma
@@ -106,9 +106,9 @@ model MyPrismaScalarsType {
   /// @zod.number.lt(10.3, { message: "lt error" }).gt(5.5, { message: "gt | error" })
   float              Float
   floatOpt           Float?
-  /// @zod.number.int({ message: "error" }).gt(5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })
+  /// @zod.number.int({ message: "error" }).gt(5, { message: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })
   int                Int
-  /// @zod.number.int({ message: "error" }).gt(-5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })
+  /// @zod.number.int({ message: "error" }).gt(-5, { message: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })
   intOpt             Int?
   decimal            Decimal
   decimalOpt         Decimal?
@@ -340,7 +340,7 @@ model SelfReference {
 
 model JapaneseChars {
   id     Int    @id @default(autoincrement())
-  ///@zod.string({ invalid_type_error: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。", required_error: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。", description: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" }).min(5, { message: "ひらがな、カタカナ、漢字が少なくとも1つずつ含まれる必要があります。" })
+  ///@zod.string({ invalid_type_error: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。", required_error: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。", description: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" }).min(5, { message: "ひらがな、カタカナ、漢字、長音符ーが少なくとも1つずつ含まれる必要があります。" })
   string String
 }
 


### PR DESCRIPTION
# Support Japanese long vowel mark "ー" (chōonpu)

## Changes
- Updated the validator regex to properly handle the Japanese long vowel mark "ー" (chōonpu).
- Added test cases including the long vowel mark to ensure correct functionality.

## Background
When dealing with Japanese text, there were cases where the long vowel mark "ー" was not processed correctly. We have extended the validator functionality to address this issue.

## Technical Details
- Updated the `VALIDATOR_TYPE_REGEX` pattern to match strings containing the long vowel mark "ー".
- Added new test cases to the `ExtendedDMMFFieldValidatorMatch` class that include the long vowel mark.
