### PR TITLE
Generated relation types are now shallow, BREAKING CHANGE

### DIFF
--- a/packages/generator/src/functions/contentWriters/writeModelOrType.ts
+++ b/packages/generator/src/functions/contentWriters/writeModelOrType.ts
@@ -222,11 +222,7 @@ export const writeModelOrType = (
             .write(field.name)
             .conditionalWrite(!field.isRequired, '?')
             .write(': ')
-            .conditionalWrite(
-              !field.isCompositeType,
-              `${field.type}WithRelations`,
-            )
-            .conditionalWrite(field.isCompositeType, `${field.type}`)
+            .write(`${field.type}`)
             .conditionalWrite(field.isList, '[]')
             .conditionalWrite(!field.isRequired, ' | null')
             .write(';')


### PR DESCRIPTION
Just a reference on how #304 could be solved. One could also add a new type `<Model>ShallowRelations`, but it would be more work to add this to all the conditionals, so I wanted to get your opinion on it first @chrishoermann. As described in the issue, I don't fully see how non-shallow relations would be actually useful.

Before this, fields in a <Model>Relations type would reference <OtherModel>Relations type, which would often reference <Model>Relations type itself, leading to infinite nesting.

Now instead the fields reference <OtherModel>
