### PR TITLE
Fix extra generation of updateManySchemas

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -32,7 +32,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\""
   },
   "devDependencies": {
-    "@prisma/internals": "^6.0.1",
+    "@prisma/internals": "^6.3.0",
     "@types/lodash": "^4.17.13",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
@@ -46,7 +46,7 @@
     "vitest": "^0.34.6"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^6.0.1",
+    "@prisma/generator-helper": "^6.3.0",
     "code-block-writer": "^12.0.0",
     "lodash": "^4.17.21",
     "zod": "^3.23.8"

--- a/packages/generator/src/classes/extendedDMMFInputType.ts
+++ b/packages/generator/src/classes/extendedDMMFInputType.ts
@@ -15,7 +15,7 @@ import {
 import { GeneratorConfig } from '../schemas';
 
 const SPLIT_NAME_REGEX =
-  /Unchecked|Create|Update|CreateMany|CreateManyAndReturn|UpdateMany|Upsert|Where|WhereUnique|OrderBy|ScalarWhere|Aggregate|GroupBy/g;
+  /Unchecked|Create|Update|CreateMany|CreateManyAndReturn|UpdateMany|UpdateManyAndReturn|Upsert|Where|WhereUnique|OrderBy|ScalarWhere|Aggregate|GroupBy/g;
 
 /////////////////////////////////////////////////
 // CLASS

--- a/packages/generator/src/classes/extendedDMMFSchema.ts
+++ b/packages/generator/src/classes/extendedDMMFSchema.ts
@@ -102,7 +102,8 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
     // Since then additional schemas would be generated that are not used anywhere
     // and that would not have a corresponding prisma type
     const modelWithoutCreateManyAndReturn = schema.outputObjectTypes.model
-      .filter((type) => !type.name.includes('AndReturn'))
+      .filter((type) => !type.name.includes('createManyAndReturn'))
+      .filter((type) => !type.name.includes('updateManyAndReturn'))
       .map((type) => {
         return new ExtendedDMMFOutputType(
           this.generatorConfig,

--- a/packages/generator/src/constants/objectMaps.ts
+++ b/packages/generator/src/constants/objectMaps.ts
@@ -104,6 +104,7 @@ export const PRISMA_ACTION_ARG_MAP: Record<
   createManyAndReturn: new FormattedNames('createManyAndReturn'),
   updateOne: new FormattedNames('update'),
   updateMany: new FormattedNames('updateMany'),
+  updateManyAndReturn: new FormattedNames('updateManyAndReturn'),
   upsertOne: new FormattedNames('upsert'),
   deleteOne: new FormattedNames('delete'),
   deleteMany: new FormattedNames('deleteMany'),
@@ -115,18 +116,16 @@ export const PRISMA_ACTION_ARG_MAP: Record<
  * This array contains all prisma actions for which
  * we want to generate a zod input schema.
  */
-export const PRISMA_ACTION_ARRAY: (
-  | Exclude<FilterdPrismaAction, 'createManyAndReturn'>
-  | 'AndReturn'
-)[] = [
+export const PRISMA_ACTION_ARRAY: FilterdPrismaAction[] = [
   'findUnique',
   'findMany',
   'findFirst',
   'createOne',
-  'AndReturn', // special case for createManyAndReturn - order is important
   'createMany',
+  'createManyAndReturn',
   'updateOne',
   'updateMany',
+  'updateManyAndReturn',
   'upsertOne',
   'deleteOne',
   'deleteMany',
@@ -139,10 +138,11 @@ export const PRISMA_ACTION_MATCHER_ARRAY: PrimsaMatcherArray[] = [
   ['findMany', 'findMany'],
   ['findFirst', 'findFirst'],
   ['createOne', 'createOne'],
-  ['AndReturn', 'createManyAndReturn'],
+  ['createManyAndReturn', 'createManyAndReturn'],
   ['createMany', 'createMany'],
   ['updateOne', 'updateOne'],
   ['updateMany', 'updateMany'],
+  ['updateManyAndReturn', 'updateManyAndReturn'],
   ['upsertOne', 'upsertOne'],
   ['deleteOne', 'deleteOne'],
   ['deleteMany', 'deleteMany'],
@@ -150,8 +150,4 @@ export const PRISMA_ACTION_MATCHER_ARRAY: PrimsaMatcherArray[] = [
   ['groupBy', 'groupBy'],
 ];
 
-type PrismaActionMapperKeys =
-  | Exclude<FilterdPrismaAction, 'createManyAndReturn'>
-  | 'AndReturn';
-
-type PrimsaMatcherArray = [PrismaActionMapperKeys, FilterdPrismaAction];
+type PrimsaMatcherArray = [FilterdPrismaAction, FilterdPrismaAction];

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -136,6 +136,7 @@ export type PrismaAction =
   | 'createManyAndReturn'
   | 'updateOne'
   | 'updateMany'
+  | 'updateManyAndReturn'
   | 'upsertOne'
   | 'deleteOne'
   | 'deleteMany'


### PR DESCRIPTION
I've created a fix to support Prisma 6.2.0 and is working when testing locally. This is an attempt to fix #306 

It also supports 6.3.0 as well.

This fix doesn't generate custom types for updateManyAndReturn but just fixes the extra schemas being generated.

I would appreciate any extra feedback on this as I'm not super familiar with this repo & any parts that I missed.