### PR TITLE
Add Support for .describe on Enums

### DIFF
--- a/packages/generator/src/classes/__tests__/cases/testValidators/enum.prisma
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/enum.prisma
@@ -1,0 +1,18 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+model EnumValidators {
+    id          Int  @id @default(autoincrement())
+    enum        TestEnum? /// @zod.enum.describe('test')
+}
+
+enum TestEnum {
+    a
+    b
+}

--- a/packages/generator/src/classes/__tests__/cases/testValidators/enum.test.ts
+++ b/packages/generator/src/classes/__tests__/cases/testValidators/enum.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+import { ExtendedDMMF } from '../../../extendedDMMF';
+import { loadDMMF } from '../../utils/loadDMMF';
+describe('test number validators', async () => {
+  const dmmf = await loadDMMF(`${__dirname}/enum.prisma`);
+  const extendedDMMF = new ExtendedDMMF(dmmf, {});
+
+  describe('test validators', () => {
+    const fields = {
+      id: extendedDMMF.datamodel.models[0].fields[0],
+      enum: extendedDMMF.datamodel.models[0].fields[1],
+    };
+
+    it(`should add describe validator for field "${fields.enum.name}"`, () => {
+      expect(fields.enum.zodValidatorString).toBe(".describe('test')");
+    });
+  });
+});

--- a/packages/generator/src/classes/extendedDMMFField/07_extendedDMMFFieldValidatorMap.ts
+++ b/packages/generator/src/classes/extendedDMMFField/07_extendedDMMFFieldValidatorMap.ts
@@ -69,6 +69,8 @@ export type ZodBigIntValidatorKeys =
   | 'multipleOf'
   | 'describe';
 
+export type ZodEnumValidatorKeys = ZodArrayValidatorKeys | 'describe';
+
 export type ZodCustomValidatorKeys = ZodArrayValidatorKeys | 'use' | 'omit';
 
 export interface ScalarValidatorFnOpts {
@@ -246,8 +248,9 @@ export const CUSTOM_VALIDATOR_REGEX_MAP: ValidatorMap<ZodCustomValidatorKeys> =
     array: ARRAY_VALIDATOR_MESSAGE_REGEX,
   };
 
-export const ENUM_VALIDATOR_REGEX_MAP: ValidatorMap<ZodArrayValidatorKeys> = {
+export const ENUM_VALIDATOR_REGEX_MAP: ValidatorMap<ZodEnumValidatorKeys> = {
   array: ARRAY_VALIDATOR_MESSAGE_REGEX,
+  describe: STRING_VALIDATOR_DESCRIBE_REGEX,
 };
 
 export const OBJECT_VALIDATOR_REGEX_MAP: ValidatorMap<ZodArrayValidatorKeys> = {

--- a/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/07_extendedDMMFFieldValidatorMap.test.ts
+++ b/packages/generator/src/classes/extendedDMMFField/__tests__/subclasses/07_extendedDMMFFieldValidatorMap.test.ts
@@ -1071,6 +1071,13 @@ export function testExtendedDMMFFieldValidatorMap<
           pattern: '.array(.length(2))',
         }),
       ).toBe(true);
+
+      expect(
+        map({
+          key: 'describe',
+          pattern: ".describe('test')",
+        }),
+      ).toBe(true);
     });
 
     it(`should pass ivalid data to to validator map`, async () => {

--- a/packages/generator/src/functions/fieldWriters/writeModelEnum.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelEnum.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { writeFieldAdditions } from '.';
 import { WriteFieldOptions } from '../../types';
 
@@ -9,7 +10,8 @@ export const writeEnum = ({
   writer
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.formattedNames.original}: `)
-    .write(`${field.zodType}Schema`);
+    .write(`${field.zodType}Schema`)
+    .conditionalWrite(!!field.zodValidatorString, field.zodValidatorString!);
 
   writeFieldAdditions({ writer, field, writeOptionalDefaults });
 };


### PR DESCRIPTION
## Add `.describe()` Support for Enums

Hello,  

I've recently started using this library and quickly ran into a limitation: `.describe()` does not work for Enums. We generate a lot of our OpenAPI schemas from Zod, and `zod-prisma-types` is proving to be quite useful as it allows us to maintain a single Prisma schema, rather than duplicating it as a Zod type and an OpenAPI schema. However, `.describe()` is crucial for generating meaningful OpenAPI schemas. While it already works for Strings, Integers, and similar types, Enums were not supported.  

### Changes in this PR  
This PR introduces support for `.describe()` on Enums. Given the following Prisma schema:  

```prisma
model EnumValidators {
    id   Int      @id @default(autoincrement())
    enum TestEnum? /// @zod.enum.describe('test')
}
```

The generated Zod schema will now include `.describe()`:  

```typescript
z.object({
  id: z.number(),
  enum: TestEnumSchema.describe("test")
});
```  

### Additional Notes  
- I've added tests to cover this change.  
- If there are any contributing guidelines I've overlooked, please do let me know—I'm happy to make any necessary amendments.  
- A number of existing tests were already failing prior to my changes and continue to do so, so these appear to be unrelated to this PR.  

Looking forward to your thoughts! Cheers. 🍻  
