### PR TITLE
feat: export all contents in inputType files

### DIFF
--- a/packages/generator/.npmignore
+++ b/packages/generator/.npmignore
@@ -1,4 +1,4 @@
-# src
+src
 node_modules
 tsconfig.json
 .eslintrc.json

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zod-prisma-types",
+  "name": "@pmcorrea/zod-prisma-types",
   "version": "3.2.5",
   "description": "Generates zod schemas from Prisma models with advanced validation",
   "author": "Chris Hörmann",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmcorrea/zod-prisma-types",
-  "version": "3.2.5",
+  "version": "3.2.7",
   "description": "Generates zod schemas from Prisma models with advanced validation",
   "author": "Chris Hörmann",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "url": "https://github.com/petercorrea/zod-prisma-types.git"
   },
   "bin": {
-    "@pmcorrea/zod-prisma-types": "dist/bin.js"
+    "zod-prisma-types": "dist/bin.js"
   },
   "scripts": {
     "lint": "eslint --ext ts,tsx,js,jsx --fix .",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/petercorrea/zod-prisma-types.git"
   },
   "bin": {
-    "zod-prisma-types": "dist/bin.js"
+    "@pmcorrea/zod-prisma-types": "dist/bin.js"
   },
   "scripts": {
     "lint": "eslint --ext ts,tsx,js,jsx --fix .",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zod-prisma-types",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Generates zod schemas from Prisma models with advanced validation",
   "author": "Chris Hörmann",
   "license": "MIT",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/chrishoermann/zod-prisma-types.git"
+    "url": "https://github.com/petercorrea/zod-prisma-types.git"
   },
   "bin": {
     "zod-prisma-types": "dist/bin.js"

--- a/packages/generator/src/classes/extendedDMMFDatamodel.ts
+++ b/packages/generator/src/classes/extendedDMMFDatamodel.ts
@@ -1,9 +1,9 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
-import { ExtendedDMMFEnum } from './extendedDMMFEnum';
-import { ExtendedDMMFModel, ExtendedDMMFModelClass } from './extendedDMMFModel';
 import { GeneratorConfig } from '../schemas';
+import { ExtendedDMMFEnum } from './extendedDMMFEnum';
 import { ExtendedDMMFIndex } from './extendedDMMFIndex';
+import { ExtendedDMMFModel, ExtendedDMMFModelClass } from './extendedDMMFModel';
 
 export interface ExtendedDMMFDatamodelOptions {
   datamodel: DMMF.Datamodel;
@@ -22,7 +22,7 @@ export class ExtendedDMMFDatamodel {
 
   constructor(
     readonly generatorConfig: GeneratorConfig,
-    datamodel: ReadonlyDeep<DMMF.Datamodel>,
+    datamodel: Readonly<DMMF.Datamodel>,
   ) {
     this.generatorConfig = generatorConfig;
     this.enums = this._getExtendedEnums(datamodel.enums);
@@ -31,19 +31,19 @@ export class ExtendedDMMFDatamodel {
     this.types = this._getExtendedModels(datamodel.types);
   }
 
-  private _getExtendedModels(models: ReadonlyDeep<DMMF.Model[]>) {
+  private _getExtendedModels(models: Readonly<DMMF.Model[]>) {
     return models.map(
       (model) => new ExtendedDMMFModelClass(this.generatorConfig, model),
     );
   }
 
-  private _getExtendedEnums(enums: ReadonlyDeep<DMMF.DatamodelEnum[]>) {
+  private _getExtendedEnums(enums: Readonly<DMMF.DatamodelEnum[]>) {
     return enums.map(
       (elem) => new ExtendedDMMFEnum(this.generatorConfig, elem),
     );
   }
 
-  private _getExtendedIndexes(indexes: ReadonlyDeep<DMMF.Index[]>) {
+  private _getExtendedIndexes(indexes: Readonly<DMMF.Index[]>) {
     return indexes.map(
       (elem) => new ExtendedDMMFIndex(this.generatorConfig, elem),
     );

--- a/packages/generator/src/classes/extendedDMMFEnum.ts
+++ b/packages/generator/src/classes/extendedDMMFEnum.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { GeneratorConfig } from '../schemas';
 import { FormattedNames } from './formattedNames';
@@ -9,7 +9,7 @@ import { FormattedNames } from './formattedNames';
 
 export class ExtendedDMMFEnum extends FormattedNames {
   readonly name: string;
-  readonly values: ReadonlyDeep<DMMF.EnumValue[]>;
+  readonly values: Readonly<DMMF.EnumValue[]>;
   readonly dbName?: string | null;
   readonly documentation?: string;
 

--- a/packages/generator/src/classes/extendedDMMFField/05_extendedDMMFFieldDefaultValidators.ts
+++ b/packages/generator/src/classes/extendedDMMFField/05_extendedDMMFFieldDefaultValidators.ts
@@ -1,13 +1,13 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
-import { ExtendedDMMFFieldValidatorPattern } from './04_extendedDMMFFieldValidatorPattern';
 import { GeneratorConfig } from '../../schemas';
+import { ExtendedDMMFFieldValidatorPattern } from './04_extendedDMMFFieldValidatorPattern';
 
 export class ExtendedDMMFFieldDefaultValidators extends ExtendedDMMFFieldValidatorPattern {
   protected _defaultValidatorString?: string;
 
   constructor(
-    field: ReadonlyDeep<DMMF.Field>,
+    field: Readonly<DMMF.Field>,
     generatorConfig: GeneratorConfig,
     modelName: string,
   ) {
@@ -49,13 +49,13 @@ export class ExtendedDMMFFieldDefaultValidators extends ExtendedDMMFFieldValidat
   // other properties will be used, but for now they are not.
 
   private _IsFieldDefault(
-    value?: ReadonlyDeep<
-      | ReadonlyDeep<DMMF.FieldDefault>
-      | ReadonlyDeep<DMMF.FieldDefaultScalar>
-      | ReadonlyDeep<DMMF.FieldDefaultScalar>[]
+    value?: Readonly<
+      | Readonly<DMMF.FieldDefault>
+      | Readonly<DMMF.FieldDefaultScalar>
+      | Readonly<DMMF.FieldDefaultScalar>[]
     >,
-  ): value is ReadonlyDeep<DMMF.FieldDefault> {
-    return (value as ReadonlyDeep<DMMF.FieldDefault>)?.name !== undefined;
+  ): value is Readonly<DMMF.FieldDefault> {
+    return (value as Readonly<DMMF.FieldDefault>)?.name !== undefined;
   }
 
   // The validator list needs to be updated after the default validator

--- a/packages/generator/src/classes/extendedDMMFInputType.ts
+++ b/packages/generator/src/classes/extendedDMMFInputType.ts
@@ -1,5 +1,10 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
+import {
+  PRISMA_FUNCTION_TYPES_WITH_VALIDATORS,
+  PRISMA_FUNCTION_TYPES_WITH_VALIDATORS_WHERE_UNIQUE,
+} from '../constants/regex';
+import { GeneratorConfig } from '../schemas';
 import { ExtendedDMMFDatamodel } from './extendedDMMFDatamodel';
 import { ExtendedDMMFField } from './extendedDMMFField';
 import { ExtendedDMMFModel } from './extendedDMMFModel';
@@ -8,11 +13,6 @@ import {
   ZodValidatorOptions,
 } from './extendedDMMFSchemaArg';
 import { FormattedNames } from './formattedNames';
-import {
-  PRISMA_FUNCTION_TYPES_WITH_VALIDATORS,
-  PRISMA_FUNCTION_TYPES_WITH_VALIDATORS_WHERE_UNIQUE,
-} from '../constants/regex';
-import { GeneratorConfig } from '../schemas';
 
 const SPLIT_NAME_REGEX =
   /Unchecked|Create|Update|CreateMany|CreateManyAndReturn|UpdateMany|UpdateManyAndReturn|Upsert|Where|WhereUnique|OrderBy|ScalarWhere|Aggregate|GroupBy/g;
@@ -75,7 +75,7 @@ export class ExtendedDMMFInputType
     });
   }
 
-  private _setFields(fields: ReadonlyDeep<DMMF.SchemaArg[]>) {
+  private _setFields(fields: Readonly<DMMF.SchemaArg[]>) {
     // FILTER FIELD REF TYPES
     // -----------------------------------------------
 
@@ -227,9 +227,7 @@ export class ExtendedDMMFInputType
     return result;
   }
 
-  private _setExtendedWhereUniqueFields(
-    fields: ReadonlyDeep<DMMF.SchemaArg[]>,
-  ) {
+  private _setExtendedWhereUniqueFields(fields: Readonly<DMMF.SchemaArg[]>) {
     if (!this.constraints.fields || !this.name.includes('WhereUniqueInput')) {
       return undefined;
     }

--- a/packages/generator/src/classes/extendedDMMFMappings.ts
+++ b/packages/generator/src/classes/extendedDMMFMappings.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { GeneratorConfig } from '../schemas';
 
@@ -7,8 +7,8 @@ import { GeneratorConfig } from '../schemas';
 /////////////////////////////////////////////////
 
 export class ExtendedDMMFMappings implements DMMF.Mappings {
-  readonly modelOperations: ReadonlyDeep<DMMF.ModelMapping[]>;
-  readonly otherOperations: ReadonlyDeep<{
+  readonly modelOperations: Readonly<DMMF.ModelMapping[]>;
+  readonly otherOperations: Readonly<{
     readonly read: string[];
     readonly write: string[];
   }>;

--- a/packages/generator/src/classes/extendedDMMFOutputType.ts
+++ b/packages/generator/src/classes/extendedDMMFOutputType.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { ExtendedDMMFModel } from '.';
 import { PRISMA_ACTION_ARRAY } from '../constants/objectMaps';
@@ -64,7 +64,7 @@ export class ExtendedDMMFOutputType
    * - Returns all fields that are not in `PRISMA_ACTION_ARRAY` if the fieldCategory is set to `OTHER_FIELDS`.
    */
   private _setFields(
-    fields: ReadonlyDeep<DMMF.SchemaField[]>,
+    fields: Readonly<DMMF.SchemaField[]>,
     datamodel: ExtendedDMMFDatamodel,
     fieldCategory?: 'PRISMA_ACTION' | 'OTHER_FIELDS',
   ) {

--- a/packages/generator/src/classes/extendedDMMFSchema.ts
+++ b/packages/generator/src/classes/extendedDMMFSchema.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import {
   ExtendedDMMFDatamodel,
@@ -23,7 +23,7 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
   readonly rootQueryType?: DMMF.Schema['rootQueryType'];
   readonly rootMutationType?: DMMF.Schema['rootMutationType'];
   readonly inputObjectTypes: {
-    readonly model?: ReadonlyDeep<DMMF.InputType[]>;
+    readonly model?: Readonly<DMMF.InputType[]>;
     /**
      * Contains information about the prisma where, orderBy, and other input types.
      */
@@ -48,11 +48,11 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
     readonly argTypes: ExtendedDMMFOutputType[];
   };
   readonly enumTypes: {
-    readonly model?: ReadonlyDeep<DMMF.SchemaEnum[]>;
+    readonly model?: Readonly<DMMF.SchemaEnum[]>;
     readonly prisma: ExtendedDMMFSchemaEnum[];
   };
   readonly fieldRefTypes: {
-    readonly prisma?: ReadonlyDeep<DMMF.FieldRefType[]>;
+    readonly prisma?: Readonly<DMMF.FieldRefType[]>;
   };
   readonly hasJsonTypes: boolean;
   readonly hasBytesTypes: boolean;
@@ -82,7 +82,7 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
   }
 
   private _setExtendedInputObjectTypes(
-    schema: ReadonlyDeep<DMMF.Schema>,
+    schema: Readonly<DMMF.Schema>,
     datamodel: ExtendedDMMFDatamodel,
   ) {
     return {
@@ -95,7 +95,7 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
   }
 
   private _setExtendedOutputObjectTypes(
-    schema: ReadonlyDeep<DMMF.Schema>,
+    schema: Readonly<DMMF.Schema>,
     datamodel: ExtendedDMMFDatamodel,
   ) {
     // The models where the name contains "CreateMany[modelName]AndReturn" must not be included!
@@ -138,7 +138,7 @@ export class ExtendedDMMFSchema implements DMMF.Schema {
     };
   }
 
-  private _setExtendedEnumTypes(schema: ReadonlyDeep<DMMF.Schema>) {
+  private _setExtendedEnumTypes(schema: Readonly<DMMF.Schema>) {
     return {
       ...schema.enumTypes,
       prisma: schema.enumTypes.prisma.map(

--- a/packages/generator/src/classes/extendedDMMFSchemaArg.ts
+++ b/packages/generator/src/classes/extendedDMMFSchemaArg.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { ExtendedDMMFField, ExtendedDMMFSchemaArgInputType } from '.';
 import { GeneratorConfig } from '../schemas';
@@ -67,7 +67,7 @@ export class ExtendedDMMFSchemaArg
     this.linkedField = linkedField;
   }
 
-  private _setInputTypes = (inputTypes: ReadonlyDeep<DMMF.InputTypeRef[]>) => {
+  private _setInputTypes = (inputTypes: Readonly<DMMF.InputTypeRef[]>) => {
     // filter "null" from the inputTypes array to prevent the generator
     // from generating a union type with "null" and the actual field type
     // instead of e.g. a scalar type

--- a/packages/generator/src/classes/extendedDMMFSchemaEnum.ts
+++ b/packages/generator/src/classes/extendedDMMFSchemaEnum.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { GeneratorConfig } from '../schemas';
 import { FormattedNames } from './formattedNames';
@@ -17,7 +17,7 @@ export class ExtendedDMMFSchemaEnum
 
   constructor(
     readonly generatorConfig: GeneratorConfig,
-    enumType: ReadonlyDeep<DMMF.SchemaEnum>,
+    enumType: Readonly<DMMF.SchemaEnum>,
   ) {
     super(enumType.name);
     this.generatorConfig = generatorConfig;

--- a/packages/generator/src/classes/extendedDMMFSchemaField.ts
+++ b/packages/generator/src/classes/extendedDMMFSchemaField.ts
@@ -1,4 +1,4 @@
-import { DMMF, ReadonlyDeep } from '@prisma/generator-helper';
+import { DMMF } from '@prisma/generator-helper';
 
 import { ExtendedDMMFDatamodel } from './extendedDMMFDatamodel';
 import { ExtendedDMMFModel } from './extendedDMMFModel';
@@ -107,7 +107,7 @@ export class ExtendedDMMFSchemaField
     return this.outputType.namespace === 'model';
   }
 
-  private _setArgs({ args }: ReadonlyDeep<DMMF.SchemaField>) {
+  private _setArgs({ args }: Readonly<DMMF.SchemaField>) {
     return args.map((arg) => {
       const linkedField = this.linkedModel?.fields.find(
         (field) => field?.name === arg?.name,

--- a/packages/generator/src/functions/writeMultiFileInputTypeFiles.ts
+++ b/packages/generator/src/functions/writeMultiFileInputTypeFiles.ts
@@ -57,7 +57,7 @@ export const writeInputTypeFiles: CreateFiles = ({ path, dmmf }) => {
           }
 
           writeExportSet.forEach((exportName) => {
-            writeExport(`{ ${exportName} }`, `./${exportName}`);
+            writeExport(`*`, `./${exportName}`);
           });
         },
       );

--- a/packages/generator/tsconfig.json
+++ b/packages/generator/tsconfig.json
@@ -22,7 +22,7 @@
     "declarationMap": true,
     "resolveJsonModule": true,
     "strictNullChecks": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
It is useful to export the already generated types. This PR simplified the named exports of inputType barrel files to export all.

@chrishoermann 