### PR TITLE
fix: type for `Bytes` incompatible with Prisma 6

### DIFF
--- a/packages/generator/src/functions/fieldWriters/writeModelBytes.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelBytes.ts
@@ -1,15 +1,25 @@
 import { writeFieldAdditions } from '.';
-import { WriteFieldOptions } from '../../types';
+import { ExtendedWriteFieldOptions } from '../../types';
 
 export const writeBytes = ({
   writer,
   field,
+  dmmf: {
+    generatorConfig: { prismaVersion },
+  },
   writeOptionalDefaults = false,
-}: WriteFieldOptions) => {
+}: ExtendedWriteFieldOptions) => {
   writer
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.formattedNames.original}: `)
-    .write(`z.instanceof(Buffer)`);
+    .conditionalWrite(
+      prismaVersion?.major === 6 || prismaVersion === undefined,
+      `z.instanceof(Uint8Array<ArrayBufferLike>)`,
+    )
+    .conditionalWrite(
+      prismaVersion?.major === 5 || prismaVersion?.major === 4,
+      `z.instanceof(Buffer)`,
+    );
 
   writeFieldAdditions({ writer, field, writeOptionalDefaults });
 };

--- a/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
+++ b/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
@@ -26,7 +26,6 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
   },
 ) => {
   if (!inputType.isSpecialType()) return;
-
   if (
     zodCustomValidatorString &&
     inputType.generatorConfig.addInputTypeValidation
@@ -98,8 +97,16 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
   }
 
   if (inputType.isBytesType) {
+    const prismaVersion = inputType.generatorConfig.prismaVersion;
     return writer
-      .write(`z.instanceof(Buffer)`)
+      .conditionalWrite(
+        prismaVersion?.major === 6 || prismaVersion === undefined,
+        `z.instanceof(Uint8Array<ArrayBufferLike>)`,
+      )
+      .conditionalWrite(
+        prismaVersion?.major === 5 || prismaVersion?.major === 4,
+        `z.instanceof(Buffer)`,
+      )
       .conditionalWrite(inputType.isList, `.array()`)
       .conditionalWrite(isOptional, `.optional()`)
       .conditionalWrite(isNullable, `.nullable()`)


### PR DESCRIPTION
Fixes #343.

Works well on my project using `prisma@6.10.0` and `zod@3.25.67`, further tests with lower Prisma versions are needed.

- writes `z.instanceof(Uint8Array<ArrayBufferLike>)` instead of `z.instanceof(Buffer)` if `prismaVersion` is `undefined` or `prismaVersion?.major === 6`.