### PR TITLE
feat: support queryCompiler and prisma-client generator

### DIFF
--- a/packages/generator/src/classes/extendedDMMFInputType.ts
+++ b/packages/generator/src/classes/extendedDMMFInputType.ts
@@ -184,14 +184,14 @@ export class ExtendedDMMFInputType
     const {
       prismaClientPath,
       prismaLibraryPath,
-      isPrismaQueryCompiler,
+      isPrismaClientGenerator,
       decimalJSInstalled,
     } = this.generatorConfig;
 
     const prismaImports = [];
 
     if (this.isDecimalField) {
-      if (isPrismaQueryCompiler) {
+      if (isPrismaClientGenerator) {
         prismaImports.push(
           `import { Decimal as PrismaDecimal } from '${prismaLibraryPath}';`,
         );
@@ -200,7 +200,7 @@ export class ExtendedDMMFInputType
       }
     }
 
-    if (!this.isDecimalField || isPrismaQueryCompiler) {
+    if (!this.isDecimalField || isPrismaClientGenerator) {
       prismaImports.push(`import type { Prisma } from '${prismaClientPath}';`);
     }
 

--- a/packages/generator/src/classes/extendedDMMFInputType.ts
+++ b/packages/generator/src/classes/extendedDMMFInputType.ts
@@ -181,10 +181,29 @@ export class ExtendedDMMFInputType
   }
 
   private _setImports() {
-    const { prismaClientPath, decimalJSInstalled } = this.generatorConfig;
-    const prismaImport = this.isDecimalField
-      ? `import { Prisma } from '${prismaClientPath}';`
-      : `import type { Prisma } from '${prismaClientPath}';`;
+    const {
+      prismaClientPath,
+      prismaLibraryPath,
+      isPrismaQueryCompiler,
+      decimalJSInstalled,
+    } = this.generatorConfig;
+
+    const prismaImports = [];
+
+    if (this.isDecimalField) {
+      if (isPrismaQueryCompiler) {
+        prismaImports.push(
+          `import { Decimal as PrismaDecimal } from '${prismaLibraryPath}';`,
+        );
+      } else {
+        prismaImports.push(`import { Prisma } from '${prismaClientPath}';`);
+      }
+    }
+
+    if (!this.isDecimalField || isPrismaQueryCompiler) {
+      prismaImports.push(`import type { Prisma } from '${prismaClientPath}';`);
+    }
+
     const decimalJSImport =
       decimalJSInstalled && this.isDecimalField
         ? `import Decimal from 'decimal.js';`
@@ -192,7 +211,7 @@ export class ExtendedDMMFInputType
     const zodImport = "import { z } from 'zod';";
 
     const fieldImports = [
-      prismaImport,
+      ...prismaImports,
       decimalJSImport,
       zodImport,
       ...this.fields.map((field) => field.getImports(this.name)).flat(),

--- a/packages/generator/src/classes/extendedDMMFModel/05_extendedDMMFModelImportStatement.ts
+++ b/packages/generator/src/classes/extendedDMMFModel/05_extendedDMMFModelImportStatement.ts
@@ -47,7 +47,12 @@ export class ExtendedDMMFModelImportStatement extends ExtendedDMMFModelValidator
   private _getAutomaticImports() {
     const statements: string[] = [];
 
-    const { inputTypePath, prismaClientPath } = this.generatorConfig;
+    const {
+      inputTypePath,
+      prismaClientPath,
+      prismaLibraryPath,
+      isPrismaQueryCompiler,
+    } = this.generatorConfig;
 
     if (this.fields.some((field) => field.isJsonType)) {
       statements.push(
@@ -56,7 +61,13 @@ export class ExtendedDMMFModelImportStatement extends ExtendedDMMFModelValidator
     }
 
     if (this.hasDecimalFields) {
-      statements.push(`import { Prisma } from '${prismaClientPath}'`);
+      if (isPrismaQueryCompiler) {
+        statements.push(
+          `import { Decimal as PrismaDecimal } from '${prismaLibraryPath}';`,
+        );
+      } else {
+        statements.push(`import { Prisma } from '${prismaClientPath}'`);
+      }
     }
 
     this.enumFields.forEach((field) => {

--- a/packages/generator/src/classes/extendedDMMFModel/05_extendedDMMFModelImportStatement.ts
+++ b/packages/generator/src/classes/extendedDMMFModel/05_extendedDMMFModelImportStatement.ts
@@ -51,7 +51,7 @@ export class ExtendedDMMFModelImportStatement extends ExtendedDMMFModelValidator
       inputTypePath,
       prismaClientPath,
       prismaLibraryPath,
-      isPrismaQueryCompiler,
+      isPrismaClientGenerator,
     } = this.generatorConfig;
 
     if (this.fields.some((field) => field.isJsonType)) {
@@ -61,7 +61,7 @@ export class ExtendedDMMFModelImportStatement extends ExtendedDMMFModelValidator
     }
 
     if (this.hasDecimalFields) {
-      if (isPrismaQueryCompiler) {
+      if (isPrismaClientGenerator) {
         statements.push(
           `import { Decimal as PrismaDecimal } from '${prismaLibraryPath}';`,
         );

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
@@ -5,17 +5,30 @@ export const writeDecimalJsLike = ({
   dmmf,
   getSingleFileContent = false,
 }: ContentWriterOptions) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    writeImport('type { Prisma }', `${prismaClientPath}`);
+    if (isPrismaQueryCompiler) {
+      writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
+    } else {
+      writeImport('type { Prisma }', `${prismaClientPath}`);
+    }
   }
+
+  const decimalJsLikeTypeName = isPrismaQueryCompiler
+    ? 'DecimalJsLike'
+    : 'Prisma.DecimalJsLike';
 
   writer
     .blankLine()
     .writeLine(
-      `export const DecimalJsLikeSchema: z.ZodType<Prisma.DecimalJsLike> = z.object({`,
+      `export const DecimalJsLikeSchema: z.ZodType<${decimalJsLikeTypeName}> = z.object({`,
     )
     .withIndentationLevel(1, () => {
       writer

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
@@ -9,19 +9,19 @@ export const writeDecimalJsLike = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
     } else {
       writeImport('type { Prisma }', `${prismaClientPath}`);
     }
   }
 
-  const decimalJsLikeTypeName = isPrismaQueryCompiler
+  const decimalJsLikeTypeName = isPrismaClientGenerator
     ? 'DecimalJsLike'
     : 'Prisma.DecimalJsLike';
 

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
@@ -5,17 +5,30 @@ export const writeDecimalJsLikeList = ({
   dmmf,
   getSingleFileContent = false,
 }: ContentWriterOptions) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    writeImport('type { Prisma }', `${prismaClientPath}`);
+    if (isPrismaQueryCompiler) {
+      writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
+    } else {
+      writeImport('type { Prisma }', `${prismaClientPath}`);
+    }
   }
+
+  const decimalJsLikeListTypeName = isPrismaQueryCompiler
+    ? 'DecimalJsLike'
+    : 'Prisma.DecimalJsLike';
 
   writer
     .blankLine()
     .writeLine(
-      `export const DecimalJsLikeListSchema: z.ZodType<Prisma.DecimalJsLike[]> = z.object({`,
+      `export const DecimalJsLikeListSchema: z.ZodType<${decimalJsLikeListTypeName}[]> = z.object({`,
     )
     .withIndentationLevel(1, () => {
       writer

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
@@ -9,19 +9,19 @@ export const writeDecimalJsLikeList = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
     } else {
       writeImport('type { Prisma }', `${prismaClientPath}`);
     }
   }
 
-  const decimalJsLikeListTypeName = isPrismaQueryCompiler
+  const decimalJsLikeListTypeName = isPrismaClientGenerator
     ? 'DecimalJsLike'
     : 'Prisma.DecimalJsLike';
 

--- a/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
@@ -9,19 +9,19 @@ export const writeInputJsonValue = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { InputJsonValue }', prismaLibraryPath);
     } else {
       writeImport('{ Prisma }', prismaClientPath);
     }
   }
 
-  const inputJsonValueTypeName = isPrismaQueryCompiler
+  const inputJsonValueTypeName = isPrismaClientGenerator
     ? 'InputJsonValue'
     : 'Prisma.InputJsonValue';
 

--- a/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
@@ -5,17 +5,30 @@ export const writeInputJsonValue = ({
   dmmf,
   getSingleFileContent = false,
 }: ContentWriterOptions) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    writeImport('{ Prisma }', prismaClientPath);
+    if (isPrismaQueryCompiler) {
+      writeImport('type { InputJsonValue }', prismaLibraryPath);
+    } else {
+      writeImport('{ Prisma }', prismaClientPath);
+    }
   }
+
+  const inputJsonValueTypeName = isPrismaQueryCompiler
+    ? 'InputJsonValue'
+    : 'Prisma.InputJsonValue';
 
   writer
     .blankLine()
     .writeLine(
-      `export const InputJsonValueSchema: z.ZodType<Prisma.InputJsonValue> = z.lazy(() =>`,
+      `export const InputJsonValueSchema: z.ZodType<${inputJsonValueTypeName}> = z.lazy(() =>`,
     )
     .withIndentationLevel(1, () => {
       writer

--- a/packages/generator/src/functions/contentWriters/writeIsValidDecimalInput.ts
+++ b/packages/generator/src/functions/contentWriters/writeIsValidDecimalInput.ts
@@ -9,18 +9,18 @@ export const writeIsValidDecimalInput = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
     } else {
       writeImport('type { Prisma }', `${prismaClientPath}`);
     }
   }
 
-  const decimalJsLikeTypeName = isPrismaQueryCompiler
+  const decimalJsLikeTypeName = isPrismaClientGenerator
     ? 'DecimalJsLike'
     : 'Prisma.DecimalJsLike';
 

--- a/packages/generator/src/functions/contentWriters/writeIsValidDecimalInput.ts
+++ b/packages/generator/src/functions/contentWriters/writeIsValidDecimalInput.ts
@@ -5,11 +5,24 @@ export const writeIsValidDecimalInput = ({
   dmmf,
   getSingleFileContent = false,
 }: ContentWriterOptions) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('type { Prisma }', `${prismaClientPath}`);
+    if (isPrismaQueryCompiler) {
+      writeImport('type { DecimalJsLike }', `${prismaLibraryPath}`);
+    } else {
+      writeImport('type { Prisma }', `${prismaClientPath}`);
+    }
   }
+
+  const decimalJsLikeTypeName = isPrismaQueryCompiler
+    ? 'DecimalJsLike'
+    : 'Prisma.DecimalJsLike';
 
   writer
     .blankLine()
@@ -21,7 +34,7 @@ export const writeIsValidDecimalInput = ({
     .withIndentationLevel(1, () => {
       writer
         .write(
-          `(v?: null | string | number | Prisma.DecimalJsLike): v is string | number | Prisma.DecimalJsLike => `,
+          `(v?: null | string | number | ${decimalJsLikeTypeName}): v is string | number | ${decimalJsLikeTypeName} => `,
         )
         .inlineBlock(() => {
           writer

--- a/packages/generator/src/functions/contentWriters/writeJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeJsonValue.ts
@@ -9,20 +9,20 @@ export const writeJsonValue = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
 
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { JsonValue }', prismaLibraryPath);
     } else {
       writeImport('type { Prisma }', prismaClientPath);
     }
   }
 
-  const jsonValueTypeName = isPrismaQueryCompiler
+  const jsonValueTypeName = isPrismaClientGenerator
     ? 'JsonValue'
     : 'Prisma.JsonValue';
 

--- a/packages/generator/src/functions/contentWriters/writeJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeJsonValue.ts
@@ -5,17 +5,31 @@ export const writeJsonValue = ({
   dmmf,
   getSingleFileContent = false,
 }: ContentWriterOptions) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
-    writeImport('type { Prisma }', prismaClientPath);
+
+    if (isPrismaQueryCompiler) {
+      writeImport('type { JsonValue }', prismaLibraryPath);
+    } else {
+      writeImport('type { Prisma }', prismaClientPath);
+    }
   }
+
+  const jsonValueTypeName = isPrismaQueryCompiler
+    ? 'JsonValue'
+    : 'Prisma.JsonValue';
 
   writer
     .blankLine()
     .writeLine(
-      `export const JsonValueSchema: z.ZodType<Prisma.JsonValue> = z.lazy(() =>`,
+      `export const JsonValueSchema: z.ZodType<${jsonValueTypeName}> = z.lazy(() =>`,
     )
     .withIndentationLevel(1, () => {
       writer

--- a/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
+++ b/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
@@ -13,7 +13,7 @@ export const writePrismaEnum = (
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
@@ -32,11 +32,11 @@ export const writePrismaEnum = (
     if (name === 'JsonNullValueInput') {
       writer
         .conditionalWrite(
-          useMultipleFiles && !isPrismaQueryCompiler,
+          useMultipleFiles && !isPrismaClientGenerator,
           `import { Prisma } from '${prismaClientPath}';`,
         )
         .conditionalWrite(
-          useMultipleFiles && isPrismaQueryCompiler,
+          useMultipleFiles && isPrismaClientGenerator,
           `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
@@ -44,7 +44,7 @@ export const writePrismaEnum = (
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
-      const jsonNullTypeName = isPrismaQueryCompiler
+      const jsonNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.JsonNull'
         : 'Prisma.JsonNull';
       writer.write(
@@ -57,11 +57,11 @@ export const writePrismaEnum = (
     if (name === 'NullableJsonNullValueInput') {
       writer
         .conditionalWrite(
-          useMultipleFiles && !isPrismaQueryCompiler,
+          useMultipleFiles && !isPrismaClientGenerator,
           `import { Prisma } from '${prismaClientPath}';`,
         )
         .conditionalWrite(
-          useMultipleFiles && isPrismaQueryCompiler,
+          useMultipleFiles && isPrismaClientGenerator,
           `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
@@ -69,10 +69,10 @@ export const writePrismaEnum = (
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
-      const jsonNullTypeName = isPrismaQueryCompiler
+      const jsonNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.JsonNull'
         : 'Prisma.JsonNull';
-      const dbNullTypeName = isPrismaQueryCompiler
+      const dbNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.DbNull'
         : 'Prisma.DbNull';
       writer.write(
@@ -84,11 +84,11 @@ export const writePrismaEnum = (
     if (name === 'JsonNullValueFilter') {
       writer
         .conditionalWrite(
-          useMultipleFiles && !isPrismaQueryCompiler,
+          useMultipleFiles && !isPrismaClientGenerator,
           `import { Prisma } from '${prismaClientPath}';`,
         )
         .conditionalWrite(
-          useMultipleFiles && isPrismaQueryCompiler,
+          useMultipleFiles && isPrismaClientGenerator,
           `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
@@ -96,13 +96,13 @@ export const writePrismaEnum = (
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
-      const jsonNullTypeName = isPrismaQueryCompiler
+      const jsonNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.JsonNull'
         : 'Prisma.JsonNull';
-      const dbNullTypeName = isPrismaQueryCompiler
+      const dbNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.DbNull'
         : 'Prisma.DbNull';
-      const anyNullTypeName = isPrismaQueryCompiler
+      const anyNullTypeName = isPrismaClientGenerator
         ? 'objectEnumValues.instances.AnyNull'
         : 'Prisma.AnyNull';
       writer.write(

--- a/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
+++ b/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
@@ -9,7 +9,12 @@ export const writePrismaEnum = (
   }: ContentWriterOptions,
   { useNativeEnum, values, name }: ExtendedDMMFSchemaEnum,
 ) => {
-  const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
+  const {
+    useMultipleFiles,
+    prismaClientPath,
+    prismaLibraryPath,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
     writeImport('{ z }', 'zod');
@@ -27,16 +32,23 @@ export const writePrismaEnum = (
     if (name === 'JsonNullValueInput') {
       writer
         .conditionalWrite(
-          useMultipleFiles,
+          useMultipleFiles && !isPrismaQueryCompiler,
           `import { Prisma } from '${prismaClientPath}';`,
+        )
+        .conditionalWrite(
+          useMultipleFiles && isPrismaQueryCompiler,
+          `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
         .write(`export const ${name}Schema = z.enum([`);
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
+      const jsonNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.JsonNull'
+        : 'Prisma.JsonNull';
       writer.write(
-        `]).transform((value) => (value === 'JsonNull' ? Prisma.JsonNull : value));`,
+        `]).transform((value) => (value === 'JsonNull' ? ${jsonNullTypeName} : value));`,
       );
 
       return;
@@ -45,16 +57,26 @@ export const writePrismaEnum = (
     if (name === 'NullableJsonNullValueInput') {
       writer
         .conditionalWrite(
-          useMultipleFiles,
+          useMultipleFiles && !isPrismaQueryCompiler,
           `import { Prisma } from '${prismaClientPath}';`,
+        )
+        .conditionalWrite(
+          useMultipleFiles && isPrismaQueryCompiler,
+          `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
         .write(`export const ${name}Schema = z.enum([`);
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
+      const jsonNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.JsonNull'
+        : 'Prisma.JsonNull';
+      const dbNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.DbNull'
+        : 'Prisma.DbNull';
       writer.write(
-        `]).transform((value) => value === 'JsonNull' ? Prisma.JsonNull : value === 'DbNull' ? Prisma.DbNull : value);`,
+        `]).transform((value) => value === 'JsonNull' ? ${jsonNullTypeName} : value === 'DbNull' ? ${dbNullTypeName} : value);`,
       );
 
       return;
@@ -62,16 +84,29 @@ export const writePrismaEnum = (
     if (name === 'JsonNullValueFilter') {
       writer
         .conditionalWrite(
-          useMultipleFiles,
+          useMultipleFiles && !isPrismaQueryCompiler,
           `import { Prisma } from '${prismaClientPath}';`,
+        )
+        .conditionalWrite(
+          useMultipleFiles && isPrismaQueryCompiler,
+          `import { objectEnumValues } from '${prismaLibraryPath}';`,
         )
         .blankLine()
         .write(`export const ${name}Schema = z.enum([`);
       values.forEach((value) => {
         writer.write(`'${value}',`);
       });
+      const jsonNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.JsonNull'
+        : 'Prisma.JsonNull';
+      const dbNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.DbNull'
+        : 'Prisma.DbNull';
+      const anyNullTypeName = isPrismaQueryCompiler
+        ? 'objectEnumValues.instances.AnyNull'
+        : 'Prisma.AnyNull';
       writer.write(
-        `]).transform((value) => value === 'JsonNull' ? Prisma.JsonNull : value === 'DbNull' ? Prisma.JsonNull : value === 'AnyNull' ? Prisma.AnyNull : value);`,
+        `]).transform((value) => value === 'JsonNull' ? ${jsonNullTypeName} : value === 'DbNull' ? ${dbNullTypeName} : value === 'AnyNull' ? ${anyNullTypeName} : value);`,
       );
 
       return;

--- a/packages/generator/src/functions/contentWriters/writeTransformJsonNull.ts
+++ b/packages/generator/src/functions/contentWriters/writeTransformJsonNull.ts
@@ -9,24 +9,24 @@ export const writeTransformJsonNull = ({
     useMultipleFiles,
     prismaClientPath,
     prismaLibraryPath,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
 
   // TODO: check how to get DbNUll and JsonNull from PrismaClient without importing the whole namespace
 
   if (useMultipleFiles && !getSingleFileContent) {
-    if (isPrismaQueryCompiler) {
+    if (isPrismaClientGenerator) {
       writeImport('type { objectEnumValues, JsonValue }', prismaLibraryPath);
     } else {
       writeImport('{ Prisma }', prismaClientPath);
     }
   }
 
-  const jsonValueTypeName = isPrismaQueryCompiler
+  const jsonValueTypeName = isPrismaClientGenerator
     ? 'JsonValue'
     : 'Prisma.JsonValue';
 
-  const nullTypesTypeName = isPrismaQueryCompiler
+  const nullTypesTypeName = isPrismaClientGenerator
     ? 'typeof objectEnumValues.instances'
     : 'Prisma.NullTypes';
 

--- a/packages/generator/src/functions/fieldWriters/writeModelDecimal.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelDecimal.ts
@@ -9,9 +9,9 @@ export const writeDecimal = ({
   writeOptionalDefaults = false,
   dmmf,
 }: ExtendedWriteFieldOptions) => {
-  const { isPrismaQueryCompiler } = dmmf.generatorConfig;
+  const { isPrismaClientGenerator } = dmmf.generatorConfig;
 
-  const decimalTypeName = isPrismaQueryCompiler
+  const decimalTypeName = isPrismaClientGenerator
     ? 'PrismaDecimal'
     : 'Prisma.Decimal';
 

--- a/packages/generator/src/functions/fieldWriters/writeModelDecimal.ts
+++ b/packages/generator/src/functions/fieldWriters/writeModelDecimal.ts
@@ -7,12 +7,19 @@ export const writeDecimal = ({
   field,
   model,
   writeOptionalDefaults = false,
+  dmmf,
 }: ExtendedWriteFieldOptions) => {
+  const { isPrismaQueryCompiler } = dmmf.generatorConfig;
+
+  const decimalTypeName = isPrismaQueryCompiler
+    ? 'PrismaDecimal'
+    : 'Prisma.Decimal';
+
   writer
     .conditionalWrite(field.omitInModel(), '// omitted: ')
     .write(`${field.formattedNames.original}: `)
     .write(
-      `z.instanceof(Prisma.Decimal, { message: "Field '${field.formattedNames.original}' must be a Decimal. Location: ['Models', '${model.formattedNames.original}']"`,
+      `z.instanceof(${decimalTypeName}, { message: "Field '${field.formattedNames.original}' must be a Decimal. Location: ['Models', '${model.formattedNames.original}']"`,
     )
     // .conditionalWrite(!!field.zodCustomErrors, field.zodCustomErrors!)
     // .write(`)`)

--- a/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
+++ b/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
@@ -49,7 +49,14 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
           inputType.generatorConfig.decimalJSInstalled,
           `z.instanceof(Decimal).array(),`,
         )
-        .write(`z.instanceof(Prisma.Decimal).array(),`)
+        .conditionalWrite(
+          inputType.generatorConfig.isPrismaQueryCompiler,
+          `z.instanceof(PrismaDecimal).array(),`,
+        )
+        .conditionalWrite(
+          !inputType.generatorConfig.isPrismaQueryCompiler,
+          `z.instanceof(Prisma.Decimal).array(),`,
+        )
         .write(`DecimalJsLikeSchema.array(),`)
         .write(`]`)
         .conditionalWrite(!!zodCustomErrors, `, ${zodCustomErrors!}`)
@@ -73,7 +80,14 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
         inputType.generatorConfig.decimalJSInstalled,
         `z.instanceof(Decimal),`,
       )
-      .write(`z.instanceof(Prisma.Decimal),`)
+      .conditionalWrite(
+        inputType.generatorConfig.isPrismaQueryCompiler,
+        `z.instanceof(PrismaDecimal),`,
+      )
+      .conditionalWrite(
+        !inputType.generatorConfig.isPrismaQueryCompiler,
+        `z.instanceof(Prisma.Decimal),`,
+      )
       .write(`DecimalJsLikeSchema,`)
       .write(`]`)
       .conditionalWrite(!!zodCustomErrors, `, ${zodCustomErrors!}`)

--- a/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
+++ b/packages/generator/src/functions/fieldWriters/writeSpecialType.ts
@@ -50,11 +50,11 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
           `z.instanceof(Decimal).array(),`,
         )
         .conditionalWrite(
-          inputType.generatorConfig.isPrismaQueryCompiler,
+          inputType.generatorConfig.isPrismaClientGenerator,
           `z.instanceof(PrismaDecimal).array(),`,
         )
         .conditionalWrite(
-          !inputType.generatorConfig.isPrismaQueryCompiler,
+          !inputType.generatorConfig.isPrismaClientGenerator,
           `z.instanceof(Prisma.Decimal).array(),`,
         )
         .write(`DecimalJsLikeSchema.array(),`)
@@ -81,11 +81,11 @@ export const writeSpecialType: WriteTypeFunction<WriteTypeOptions> = (
         `z.instanceof(Decimal),`,
       )
       .conditionalWrite(
-        inputType.generatorConfig.isPrismaQueryCompiler,
+        inputType.generatorConfig.isPrismaClientGenerator,
         `z.instanceof(PrismaDecimal),`,
       )
       .conditionalWrite(
-        !inputType.generatorConfig.isPrismaQueryCompiler,
+        !inputType.generatorConfig.isPrismaClientGenerator,
         `z.instanceof(Prisma.Decimal),`,
       )
       .write(`DecimalJsLikeSchema,`)

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -12,13 +12,13 @@ export const writeSingleFileImportStatements: WriteStatements = (
     prismaClientPath,
     prismaLibraryPath,
     decimalJSInstalled,
-    isPrismaQueryCompiler,
+    isPrismaClientGenerator,
   } = dmmf.generatorConfig;
   writeImport('{ z }', 'zod');
 
-  // If using the "no-rust" query compiler, we can import directly from the
+  // If using the "prisma-client" compiler, we can import directly from the
   // runtime library to avoid importing the entire client.
-  if (isPrismaQueryCompiler) {
+  if (isPrismaClientGenerator) {
     const namesToImport = [];
 
     if (dmmf.schema.hasJsonTypes) {

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -8,17 +8,43 @@ export const writeSingleFileImportStatements: WriteStatements = (
   dmmf,
   { writer, writeImport },
 ) => {
-  const { prismaClientPath, decimalJSInstalled } = dmmf.generatorConfig;
+  const {
+    prismaClientPath,
+    prismaLibraryPath,
+    decimalJSInstalled,
+    isPrismaQueryCompiler,
+  } = dmmf.generatorConfig;
   writeImport('{ z }', 'zod');
 
-  // Prisma should primarily be imported as a type, but if there are json fields,
-  // we need to import the whole namespace because the null transformation
-  // relies on the Prisma.JsonNull and Prisma.DbNull objects
+  // If using the "no-rust" query compiler, we can import directly from the
+  // runtime library to avoid importing the entire client.
+  if (isPrismaQueryCompiler) {
+    const namesToImport = [];
 
-  if (dmmf.schema.hasJsonTypes || dmmf.schema.hasDecimalTypes) {
-    writeImport(`{ Prisma }`, `${prismaClientPath}`);
-  } else {
+    if (dmmf.schema.hasJsonTypes) {
+      namesToImport.push('JsonValue');
+      namesToImport.push('InputJsonValue');
+      namesToImport.push('objectEnumValues');
+    }
+
+    if (dmmf.schema.hasDecimalTypes) {
+      namesToImport.push('Decimal as PrismaDecimal');
+      namesToImport.push('DecimalJsLike');
+    }
+
+    if (namesToImport.length > 0) {
+      writeImport(`{ ${namesToImport.join(', ')} }`, `${prismaLibraryPath}`);
+    }
     writeImport(`type { Prisma }`, `${prismaClientPath}`);
+  } else {
+    // Prisma should primarily be imported as a type, but if there are json fields,
+    // we need to import the whole namespace because the null transformation
+    // relies on the Prisma.JsonNull and Prisma.DbNull objects
+    if (dmmf.schema.hasJsonTypes || dmmf.schema.hasDecimalTypes) {
+      writeImport(`{ Prisma }`, `${prismaClientPath}`);
+    } else {
+      writeImport(`type { Prisma }`, `${prismaClientPath}`);
+    }
   }
 
   if (dmmf.schema.hasDecimalTypes && decimalJSInstalled) {

--- a/packages/generator/src/schemas/generatorConfigSchema.ts
+++ b/packages/generator/src/schemas/generatorConfigSchema.ts
@@ -95,7 +95,7 @@ export const configSchema = z.object({
   outputTypePath: z.string().optional().default('outputTypeSchemas'), // currently only used internally
   prismaVersion: PrismaVersionSchema.optional(),
   decimalJSInstalled: z.boolean().default(false),
-  isPrismaQueryCompiler: z.boolean().default(false),
+  isPrismaClientGenerator: z.boolean().default(false),
   prismaLibraryPath: z
     .string()
     .optional()

--- a/packages/generator/src/schemas/generatorConfigSchema.ts
+++ b/packages/generator/src/schemas/generatorConfigSchema.ts
@@ -95,6 +95,11 @@ export const configSchema = z.object({
   outputTypePath: z.string().optional().default('outputTypeSchemas'), // currently only used internally
   prismaVersion: PrismaVersionSchema.optional(),
   decimalJSInstalled: z.boolean().default(false),
+  isPrismaQueryCompiler: z.boolean().default(false),
+  prismaLibraryPath: z
+    .string()
+    .optional()
+    .default('@prisma/client/runtime/library'),
 });
 
 export type GeneratorConfig = z.infer<typeof configSchema>;

--- a/packages/generator/src/utils/getPrismaClientGeneratorConfig.ts
+++ b/packages/generator/src/utils/getPrismaClientGeneratorConfig.ts
@@ -1,24 +1,33 @@
 import { GeneratorOptions } from '@prisma/generator-helper';
 import path from 'path';
 
-export const getPrismaClientOutputPath = (options: GeneratorOptions) => {
+export const getPrismaClientGeneratorConfig = (options: GeneratorOptions) => {
   // find the prisma client config
   const prismaClientOptions = options.otherGenerators.find(
-    (g) => g.provider.value === 'prisma-client-js',
+    (g) =>
+      g.provider.value === 'prisma-client-js' ||
+      g.provider.value === 'prisma-client',
   );
+
+  const isPrismaQueryCompiler =
+    prismaClientOptions?.previewFeatures.includes('queryCompiler');
+
   // check if custom output is used on generator or prisma client
   if (
     !options.generator.output?.value ||
     !prismaClientOptions?.isCustomOutput ||
     !prismaClientOptions?.output?.value
   )
-    return undefined;
+    return { isPrismaQueryCompiler };
 
   // check if the prisma client path is already set in the generator config
   // if so this path is used instead of the automatically located path
 
   if (options.generator.config?.['prismaClientPath']) {
-    return { prismaClientPath: options.generator.config?.['prismaClientPath'] };
+    return {
+      isPrismaQueryCompiler,
+      prismaClientPath: options.generator.config?.['prismaClientPath'],
+    };
   }
 
   // get the relative path to the prisma schema
@@ -26,14 +35,17 @@ export const getPrismaClientOutputPath = (options: GeneratorOptions) => {
     .relative(options.generator.output.value, prismaClientOptions.output.value)
     .replace(/\\/g, '/');
 
-  if (!prismaClientPath) return undefined;
+  if (!prismaClientPath) return { isPrismaQueryCompiler };
 
   // if multiple files are used the path needs to add one level up
   // because the schemas are generated in subfolders of the output path
   if (options.generator.config?.['useMultipleFiles']) {
-    return { prismaClientPath: `../${prismaClientPath}` };
+    return {
+      isPrismaQueryCompiler,
+      prismaClientPath: `../${prismaClientPath}`,
+    };
   }
 
   // return path to be spread into the generator config
-  return { prismaClientPath };
+  return { isPrismaQueryCompiler, prismaClientPath };
 };

--- a/packages/generator/src/utils/index.ts
+++ b/packages/generator/src/utils/index.ts
@@ -1,6 +1,6 @@
 export * from './getAllBoolCombinations';
 export * from './getStringVariants';
-export * from './getPrismaClientOutputPath';
+export * from './getPrismaClientGeneratorConfig';
 export * from './getPrismaDbProvider';
 export * from './getPrismaVersion';
 export * from './parseGeneratorConfig';

--- a/packages/generator/src/utils/parseGeneratorConfig.ts
+++ b/packages/generator/src/utils/parseGeneratorConfig.ts
@@ -1,6 +1,6 @@
 import { GeneratorOptions } from '@prisma/generator-helper';
 
-import { getPrismaClientOutputPath } from './getPrismaClientOutputPath';
+import { getPrismaClientGeneratorConfig } from './getPrismaClientGeneratorConfig';
 import { getPrismaClientProvider } from './getPrismaDbProvider';
 import { configSchema } from '../schemas';
 import { getPrismaVersion } from './getPrismaVersion';
@@ -12,7 +12,7 @@ export const parseGeneratorConfig = (generatorOptions: GeneratorOptions) => {
 
   return configSchema.parse({
     ...generatorOptions.generator.config,
-    ...getPrismaClientOutputPath(generatorOptions),
+    ...getPrismaClientGeneratorConfig(generatorOptions),
     ...getPrismaClientProvider(generatorOptions),
     prismaVersion: getPrismaVersion(),
     decimalJSInstalled: getDecimalJSInstalled(),


### PR DESCRIPTION
This PR updates the imports to support using the generated schemas in bundles targeted at the browser. Without these changes, the Zod schema cannot be used in the browser when using the new `prisma-client` generator.